### PR TITLE
Use 'babel' Prettier parser instead of deprecated 'babylon'.

### DIFF
--- a/packages/jest-fela-bindings/src/createSnapshotFactory.js
+++ b/packages/jest-fela-bindings/src/createSnapshotFactory.js
@@ -15,7 +15,7 @@ function formatHTML(html) {
   })
 
   const jsx = converter.convert(html)
-  return format(jsx, { parser: 'babylon' }).replace(/[\\"]/g, '')
+  return format(jsx, { parser: 'babel' }).replace(/[\\"]/g, '')
 }
 
 export default function createSnapshotFactory(


### PR DESCRIPTION
## Description

Using `jest-react-fela`, we get a deprecation warning.
This updates the Prettier parser in the `jest-fela-bindings` package.

```
console.warn node_modules/prettier/index.js:7939
   { parser: "babylon" } is deprecated; we now treat it as { parser: "babel" }.
```

## Packages

-none

## Versioning

Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

