### PR TITLE
chore: remove `fela` from `peerDependencies` in fela-plugin-embedded

### DIFF
--- a/packages/fela-plugin-embedded/package.json
+++ b/packages/fela-plugin-embedded/package.json
@@ -21,9 +21,6 @@
   ],
   "author": "Robin Frischmann",
   "license": "MIT",
-  "peerDependencies": {
-    "fela": "^10.0.0"
-  },
   "dependencies": {
     "fast-loops": "^1.0.0",
     "isobject": "^3.0.1"


### PR DESCRIPTION
## Description

`fela` is a `peerDependency` or that plugin.

## Packages

- `fela-plugin-embedded`

## Versioning
Patch