### PR TITLE
Don't attempt to use `document` when it may not exist

### DIFF
--- a/packages/fela-bindings/src/RendererProviderFactory.js
+++ b/packages/fela-bindings/src/RendererProviderFactory.js
@@ -2,11 +2,13 @@
 import { render, rehydrate } from 'fela-dom'
 import objectEach from 'fast-loops/lib/objectEach'
 
-function hasDOM(renderer, targetDocument = document) {
+function hasDOM(renderer, targetDocument) {
+  if (typeof window === 'undefined') return false
+  if (!targetDocument) targetDocument = document
+
   return (
     renderer &&
     !renderer.isNativeRenderer &&
-    typeof window !== 'undefined' &&
     targetDocument &&
     targetDocument.createElement
   )


### PR DESCRIPTION
## Description

Resolves #727

- Stops using `document` as a default parameter when it may not be available

## Packages
List all packages that have been changed.

- fela-bindings

## Versioning

(No versioning changes - let me know if you want me to do anything, otherwise I'll leave releasing a new version to you 🙂)

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

