### PR TITLE
Add index.d.ts to packaged files.

### DIFF
--- a/packages/fela-plugin-typescript/package.json
+++ b/packages/fela-plugin-typescript/package.json
@@ -10,6 +10,7 @@
   "files": [
     "LICENSE",
     "README.md",
+    "index.d.ts",
     "lib/**",
     "es/**"
   ],


### PR DESCRIPTION
## Description
I noticed the `index.d.ts` was missing in the published fela-plugin-typescript package, it was simply missing an entry in the `files` field.

## Packages
List all packages that have been changed.

- fela-plugin-typescript

## Versioning
None

## Checklist

#### Quality Assurance
N/A

#### Changes
N/A

