### PR TITLE
Fix clear on removed nodes

### DIFF
--- a/packages/fela-dom/src/dom/connection/__tests__/__snapshots__/createSubscription-test.js.snap
+++ b/packages/fela-dom/src/dom/connection/__tests__/__snapshots__/createSubscription-test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`Subscribing to the DOM should clear all DOM nodes 1`] = `"<head></head>"`;
 
+exports[`Subscribing to the DOM should clear when DOM nodes are already removed 1`] = `"<head></head>"`;
+
 exports[`Subscribing to the DOM should correctly recreate nodes after clean 1`] = `
 "<head>
   <style data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\">

--- a/packages/fela-dom/src/dom/connection/__tests__/createSubscription-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/createSubscription-test.js
@@ -132,6 +132,40 @@ describe('Subscribing to the DOM', () => {
     ).toMatchSnapshot()
   })
 
+  it('should clear when DOM nodes are already removed', () => {
+    const renderer = createRenderer({ devMode: true })
+
+    const updateSubscription = createSubscription(renderer)
+    renderer.subscribe(updateSubscription)
+
+    renderer.renderRule(() => ({
+      color: 'blue',
+      '@media (min-width: 300px)': {
+        color: 'red',
+        '@media (max-height: 500px)': {
+          color: 'yellow',
+        },
+      },
+    }))
+
+    renderer.renderKeyframe(() => ({
+      from: { color: 'red' },
+      to: { color: 'blue' },
+    }))
+
+    while (document.head.firstChild) {
+      document.head.removeChild(document.head.firstChild)
+    }
+
+    renderer.clear()
+
+    expect(
+      beautify(document.head.outerHTML, {
+        indent_size: 2,
+      })
+    ).toMatchSnapshot()
+  })
+
   it('should correctly recreate nodes after clean', () => {
     const renderer = createRenderer({ devMode: true })
 

--- a/packages/fela-dom/src/dom/connection/__tests__/createSubscription-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/createSubscription-test.js
@@ -153,10 +153,7 @@ describe('Subscribing to the DOM', () => {
       to: { color: 'blue' },
     }))
 
-    while (document.head.firstChild) {
-      document.head.removeChild(document.head.firstChild)
-    }
-
+    cleanHead()
     renderer.clear()
 
     expect(

--- a/packages/fela-dom/src/dom/connection/createSubscription.js
+++ b/packages/fela-dom/src/dom/connection/createSubscription.js
@@ -22,7 +22,7 @@ export default function createSubscription(
   return change => {
     if (change.type === CLEAR_TYPE) {
       objectEach(renderer.nodes, ({ node }) =>
-        node.parentNode.removeChild(node)
+        node.parentNode && node.parentNode.removeChild(node)
       )
 
       renderer.nodes = {}

--- a/packages/fela-dom/src/dom/connection/createSubscription.js
+++ b/packages/fela-dom/src/dom/connection/createSubscription.js
@@ -21,8 +21,9 @@ export default function createSubscription(
 ): Function {
   return change => {
     if (change.type === CLEAR_TYPE) {
-      objectEach(renderer.nodes, ({ node }) =>
-        node.parentNode && node.parentNode.removeChild(node)
+      objectEach(
+        renderer.nodes,
+        ({ node }) => node.parentNode && node.parentNode.removeChild(node)
       )
 
       renderer.nodes = {}


### PR DESCRIPTION
## Description
I'm using Fela in conjunction with Storybook and I'm having the problem that Storybook sometimes removes the Fela style nodes on hot reload before I can call `clear` which would end up in an error, this PR solves this problem by checking if the `parentNode` exists before trying to remove the node. 

This is not directly related to Storybook and I can see other cases where this could happen.

**EDIT: Found out that the renderer got recreated in the Storybook config file on hot reload. Moving the renderer into its own module solved the problem without needing this fix, this fix might still be applicable in other cases tho, if you don't think this is something Fela should handle you can close this PR**

## Example
N/A

## Packages

- fela-dom

## Versioning
None

## Checklist

#### Quality Assurance
- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes

- [x] Tests have been added/updated
- [ ] Documentation has been added/updated
- [x] My changes have proper flow-types

