### PR TITLE
Respect _className in combineRules

### DIFF
--- a/packages/fela/src/__tests__/combineRules-test.js
+++ b/packages/fela/src/__tests__/combineRules-test.js
@@ -72,7 +72,7 @@ describe('Combining rules', () => {
   })
 
   it.only('should merge _className as a special key', () => {
-    const rule = props => ({
+    const rule = () => ({
       _className: 'foo bar',
       color: 'red',
       padding: 10,

--- a/packages/fela/src/__tests__/combineRules-test.js
+++ b/packages/fela/src/__tests__/combineRules-test.js
@@ -71,7 +71,7 @@ describe('Combining rules', () => {
     })
   })
 
-  it.only('should merge _className as a special key', () => {
+  it('should merge _className as a special key', () => {
     const rule = () => ({
       _className: 'foo bar',
       color: 'red',

--- a/packages/fela/src/__tests__/combineRules-test.js
+++ b/packages/fela/src/__tests__/combineRules-test.js
@@ -70,4 +70,31 @@ describe('Combining rules', () => {
       padding: 20,
     })
   })
+
+  it.only('should merge _className as a special key', () => {
+    const rule = props => ({
+      _className: 'foo bar',
+      color: 'red',
+      padding: 10,
+    })
+
+    const anotherRule = props => ({
+      _className: props.cls,
+      backgroundColor: 'blue',
+      padding: 20,
+    })
+
+    const combinedRule = combineRules(rule, anotherRule)
+
+    expect(
+      combinedRule({
+        cls: 'baz',
+      })
+    ).toEqual({
+      _className: 'foo bar baz',
+      color: 'red',
+      backgroundColor: 'blue',
+      padding: 20,
+    })
+  })
 })

--- a/packages/fela/src/combineRules.js
+++ b/packages/fela/src/combineRules.js
@@ -27,7 +27,18 @@ export default function combineRules(
   return (props, renderer) =>
     arrayReduce(
       rules,
-      (style, rule) => assignStyle(style, resolveRule(rule, props, renderer)),
+      (style, rule) => {
+        const resolvedRule = resolveRule(rule, props, renderer)
+
+        // special combination of our special _className key
+        if (style._className) {
+          resolvedRule._className =
+            style._className +
+            (resolvedRule._className ? ' ' + resolvedRule._className : '')
+        }
+
+        return assignStyle(style, resolvedRule)
+      },
       {}
     )
 }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This PR adds the ability to combine _className keys in `combineRules`.

## Example
If required, add a code example or a link to a working example (repository).

```javascript
const foo = () => ({
  _className: "foo",
  color: "blue"
})

const bar = () => ({
  _className: "bar",
  fontSize: 15
})

const combined = combineRules(foo, bar)()

combined === {
  _className: "foo bar",
  color: "red",
  fontSize: 15
}
```


## Versioning
Major

Even though minimal, this actually is a major change.

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

