### PR TITLE
Documenting lack of IE 11 support for createComponentWithProxy

### DIFF
--- a/docs/api/bindings/createComponentWithProxy.md
+++ b/docs/api/bindings/createComponentWithProxy.md
@@ -2,6 +2,8 @@
 
 Sometimes you need/want to pass all the props the to child element but doesn't know them all except the one you use in your rules. `createComponentWithProxy`allow you to pass all the props to the child by default except the props used in the rules.
 
+> Note, does not work in browsers that lack [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) (like IE 11)
+
 ## Usage
 
 This can be used in different cases:


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Documenting lack of IE 11 support for createComponentWithProxy as mentioned in #468

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [ ] The code was formatted using Prettier (`yarn run format`)
- [ ] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
- [ ] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [x] Documentation has been added/updated
- [ ] My changes have proper flow-types

