### PR TITLE
 improvements for fela-plugin-friendly-pseudo-class

### DIFF
--- a/packages/fela-plugin-friendly-pseudo-class/src/__tests__/friendlyPseudoClass-test.js
+++ b/packages/fela-plugin-friendly-pseudo-class/src/__tests__/friendlyPseudoClass-test.js
@@ -16,6 +16,38 @@ describe('Friendly pseudo class plugin', () => {
       },
     })
   })
+  
+  it('should replace friendly with valid pseudo elements', () => {
+    const style = {
+      width: 20,
+      onAfter: {
+        color: 'red',
+      },
+    }
+
+    expect(friendlyPseudoClass()(style)).toEqual({
+      width: 20,
+      '::after': {
+        color: 'red',
+      },
+    })
+  })
+  
+  it('should replace friendly with valid hyphen-seperated pseudo classes', () => {
+    const style = {
+      width: 20,
+      onFirstOfType: {
+        color: 'red',
+      },
+    }
+
+    expect(friendlyPseudoClass()(style)).toEqual({
+      width: 20,
+      ':first-of-type': {
+        color: 'red',
+      },
+    })
+  })
 
   it('should resolve nested pseudo class objects', () => {
     const style = {

--- a/packages/fela-plugin-friendly-pseudo-class/src/__tests__/friendlyPseudoClass-test.js
+++ b/packages/fela-plugin-friendly-pseudo-class/src/__tests__/friendlyPseudoClass-test.js
@@ -16,7 +16,7 @@ describe('Friendly pseudo class plugin', () => {
       },
     })
   })
-  
+
   it('should replace friendly with valid pseudo elements', () => {
     const style = {
       width: 20,
@@ -32,7 +32,7 @@ describe('Friendly pseudo class plugin', () => {
       },
     })
   })
-  
+
   it('should replace friendly with valid hyphen-seperated pseudo classes', () => {
     const style = {
       width: 20,

--- a/packages/fela-plugin-friendly-pseudo-class/src/index.js
+++ b/packages/fela-plugin-friendly-pseudo-class/src/index.js
@@ -1,30 +1,45 @@
 /* @flow */
 import isPlainObject from 'isobject'
 
-const regex = new RegExp('^on([A-Z])')
+const regex = new RegExp('^on([A-Z])');
+const pseudoElements = [
+  'after',
+  'before',
+  'first-letter',
+  'first-line',
+  'selection',
+  'backdrop',
+  'placeholder',
+  'marker',
+  'spelling-error',
+  'grammar-error'
+];
 
 function friendlyPseudoClass(style: Object): Object {
   for (const property in style) {
-    const value = style[property]
+    const value = style[property];
 
     if (isPlainObject(value)) {
-      const resolvedValue = friendlyPseudoClass(value)
+      const resolvedValue = friendlyPseudoClass(value);
 
       if (regex.test(property)) {
-        const pseudo = property.replace(
-          regex,
-          (match, p1) => `:${p1.toLowerCase()}`
-        )
+        const pseudo = property
+          .replace(/([A-Z])/g, (match: string) => '-' + match.toLowerCase())
+          .replace(
+            /^on-(.*)/g,
+            (match, p1: string) =>
+              `${pseudoElements.includes(p1) ? '::' : ':'}${p1}`
+          );
 
-        style[pseudo] = resolvedValue
-        delete style[property]
+        style[pseudo] = resolvedValue;
+        delete style[property];
       } else {
-        style[property] = resolvedValue
+        style[property] = resolvedValue;
       }
     }
   }
 
-  return style
+  return style;
 }
 
 export default () => friendlyPseudoClass

--- a/packages/fela-plugin-friendly-pseudo-class/src/index.js
+++ b/packages/fela-plugin-friendly-pseudo-class/src/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 import isPlainObject from 'isobject'
 
-const regex = new RegExp('^on([A-Z])');
+const regex = new RegExp('^on([A-Z])')
 const pseudoElements = [
   'after',
   'before',
@@ -12,15 +12,15 @@ const pseudoElements = [
   'placeholder',
   'marker',
   'spelling-error',
-  'grammar-error'
-];
+  'grammar-error',
+]
 
 function friendlyPseudoClass(style: Object): Object {
   for (const property in style) {
-    const value = style[property];
+    const value = style[property]
 
     if (isPlainObject(value)) {
-      const resolvedValue = friendlyPseudoClass(value);
+      const resolvedValue = friendlyPseudoClass(value)
 
       if (regex.test(property)) {
         const pseudo = property
@@ -29,17 +29,17 @@ function friendlyPseudoClass(style: Object): Object {
             /^on-(.*)/g,
             (match, p1: string) =>
               `${pseudoElements.includes(p1) ? '::' : ':'}${p1}`
-          );
+          )
 
-        style[pseudo] = resolvedValue;
-        delete style[property];
+        style[pseudo] = resolvedValue
+        delete style[property]
       } else {
-        style[property] = resolvedValue;
+        style[property] = resolvedValue
       }
     }
   }
 
-  return style;
+  return style
 }
 
 export default () => friendlyPseudoClass


### PR DESCRIPTION
## Description
I made two improvements for fela-plugin-friendly-pseudo-class:

- firstly pseudo-elements are now supported (with '::' at the beginning, e.g. onAfter => '::after') 
- secondly the strings/properties are now better parsed (e.g. you had to use 'onFirst-of-type' for ':first-of-type' before, now onFirstOfType works as well).

## Example
For example
```javascript
onFirstOfType: {...}
onAfter: {...}
```
leads now to
```javascript
':first-of-type': {...}
'::after': {...}
```

## Packages

- fela-plugin-friendly-pseudo-class

## Versioning
Minor or Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [ ] Documentation has been added/updated
- [x] My changes have proper flow-types
