### PR TITLE
Allow enhancers to control identifier generation

### DIFF
--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -89,6 +89,10 @@ export default function createRenderer(
       return ++renderer.uniqueRuleIdentifier
     },
 
+    getNextKeyframeIdentifier() {
+      return ++renderer.uniqueKeyframeIdentifier
+    },
+
     renderRule(rule: Function, props: Object = {}): string {
       return renderer._renderStyle(rule(props, renderer), props)
     },
@@ -107,8 +111,7 @@ export default function createRenderer(
       if (!renderer.cache.hasOwnProperty(keyframeReference)) {
         // use another unique identifier to ensure minimal css markup
         const animationName =
-          renderer.selectorPrefix +
-          generateAnimationName(++renderer.uniqueKeyframeIdentifier)
+          renderer.selectorPrefix + renderer.generateAnimationName(props)
 
         const cssKeyframe = cssifyKeyframe(
           processedKeyframe,
@@ -127,6 +130,9 @@ export default function createRenderer(
       }
 
       return renderer.cache[keyframeReference].name
+    },
+    generateAnimationName(_props: Object) {
+      return generateAnimationName(renderer.getNextKeyframeIdentifier())
     },
 
     renderFont(
@@ -278,9 +284,12 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
 
             const className =
               renderer.selectorPrefix +
-              generateClassName(
-                renderer.getNextRuleIdentifier,
-                renderer.filterClassName
+              renderer.generateClassName(
+                property,
+                value,
+                pseudo,
+                media,
+                support
               )
 
             const declaration = cssifyDeclaration(property, value)
@@ -310,6 +319,18 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
       }
 
       return classNames
+    },
+    generateClassName(
+      _property: string,
+      _value: any,
+      _pseudo?: string,
+      _media?: string,
+      _support?: string
+    ): string {
+      return generateClassName(
+        renderer.getNextRuleIdentifier,
+        renderer.filterClassName
+      )
     },
 
     _emitChange(change: Object): void {


### PR DESCRIPTION
## Description

Move the existing class and animation name creation logic to separate methods on the renderer object which can be overridden by enhancers.

This enables the creation of enhancers which modify the identifier name generation without needing to re-implement the full `_renderStyleToClassNames` or `renderKeyframe` methods.

Importantly, this helps unblock concerns like https://github.com/robinweser/fela/issues/493 by shifting more control to the consumer.

## Example

Here's a basic example of how an enhancer could leverage this change:

```javascript
function generateAtomicClassName(property, value, pseudo, media, support) {
  // Return a unique deterministic class name derived from the current style.
};

function atomicClassNames() {
  return (renderer) => {
    renderer.generateClassName = (property, value, pseudo, media, support) => {
      return generateAtomicClassName(property, value, pseudo, media, support);
    };

    return renderer;
  };
};

const renderer = createRenderer({
  enhancers: [atomicClassNames()],
});
```

## Packages
`/packages/fela`

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types
