### PR TITLE
implement returning style object for native renderer

### DIFF
--- a/packages/fela-bindings/src/FelaComponentFactory.js
+++ b/packages/fela-bindings/src/FelaComponentFactory.js
@@ -17,20 +17,28 @@ export default function FelaComponentFactory(
 
       return createElement(FelaTheme, undefined, theme => {
         // TODO: could optimize perf by not calling combineRules if not necessary
-        const className = renderer.renderRule(combineRules(style), {
+        const renderedRule = renderer.renderRule(combineRules(style), {
           ...otherProps,
           theme,
         })
 
         if (children instanceof Function) {
           return children({
-            className,
+            className: !renderer.isNativeRenderer && renderedRule,
+            style: renderer.isNativeRenderer && renderedRule,
             theme,
             as,
           })
         }
 
-        return createElement(as, { className }, children)
+        return createElement(
+          as,
+          {
+            className: !renderer.isNativeRenderer && renderedRule,
+            style: renderer.isNativeRenderer && renderedRule,
+          },
+          children
+        )
       })
     }
 


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
I fixed the bug in #762. As far as I understand, checking `renderer.isNativeRenderer` should be enough to return either `className` prop for DOM or `style` prop for native.

## Packages
List all packages that have been changed.

- fela-bindings

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

