### PR TITLE
IE 11 Support Error "Object doesn't support property or method 'findI…

### DIFF
--- a/packages/fela-utils/src/findIndex.js
+++ b/packages/fela-utils/src/findIndex.js
@@ -1,0 +1,11 @@
+// workaround, because can't use native Array findIndex in IE https://github.com/robinweser/fela/pull/766
+export default function findIndex(array, predicate) {
+  var index = -1;
+  for (var i = 0; i < array.length; i++) {
+    if (predicate(array[i])) {
+      index = i;
+      break;
+    }
+  }
+  return index;
+}

--- a/packages/fela-utils/src/findIndex.js
+++ b/packages/fela-utils/src/findIndex.js
@@ -1,11 +1,11 @@
 // workaround, because can't use native Array findIndex in IE https://github.com/robinweser/fela/pull/766
 export default function findIndex(array, predicate) {
-  var index = -1;
+  var index = -1
   for (var i = 0; i < array.length; i++) {
     if (predicate(array[i])) {
-      index = i;
-      break;
+      index = i
+      break
     }
   }
-  return index;
+  return index
 }

--- a/packages/fela-utils/src/objectSortByScore.js
+++ b/packages/fela-utils/src/objectSortByScore.js
@@ -1,8 +1,8 @@
 /* @flow */
 import arrayReduce from 'fast-loops/lib/arrayReduce'
-import objectReduce from 'fast-loops/lib/objectReduce'
-
+import findIndex from './findIndex';
 import insertAtIndex from './insertAtIndex'
+import objectReduce from 'fast-loops/lib/objectReduce'
 
 // TODO: we can further improve this one
 export default function objectSortByScore(
@@ -12,9 +12,9 @@ export default function objectSortByScore(
   const sortedKeys = objectReduce(
     obj,
     (resultSortedKeys, value, key) => {
-      const index = resultSortedKeys.findIndex(
-        el => getScore(obj[el], el) > getScore(value, key)
-      )
+      const index = findIndex(resultSortedKeys, (el) => {
+        return getScore(obj[el], el) > getScore(value, key);
+      });
 
       if (index !== -1) {
         return insertAtIndex(resultSortedKeys, key, index)

--- a/packages/fela-utils/src/objectSortByScore.js
+++ b/packages/fela-utils/src/objectSortByScore.js
@@ -12,7 +12,10 @@ export default function objectSortByScore(
   const sortedKeys = objectReduce(
     obj,
     (resultSortedKeys, value, key) => {
-      const index = findIndex(resultSortedKeys, el => getScore(obj[el], el) > getScore(value, key))
+      const index = findIndex(
+        resultSortedKeys,
+        el => getScore(obj[el], el) > getScore(value, key)
+      )
 
       if (index !== -1) {
         return insertAtIndex(resultSortedKeys, key, index)

--- a/packages/fela-utils/src/objectSortByScore.js
+++ b/packages/fela-utils/src/objectSortByScore.js
@@ -1,6 +1,6 @@
 /* @flow */
 import arrayReduce from 'fast-loops/lib/arrayReduce'
-import findIndex from './findIndex';
+import findIndex from './findIndex'
 import insertAtIndex from './insertAtIndex'
 import objectReduce from 'fast-loops/lib/objectReduce'
 
@@ -12,9 +12,9 @@ export default function objectSortByScore(
   const sortedKeys = objectReduce(
     obj,
     (resultSortedKeys, value, key) => {
-      const index = findIndex(resultSortedKeys, (el) => {
-        return getScore(obj[el], el) > getScore(value, key);
-      });
+      const index = findIndex(resultSortedKeys, el => {
+        return getScore(obj[el], el) > getScore(value, key)
+      })
 
       if (index !== -1) {
         return insertAtIndex(resultSortedKeys, key, index)

--- a/packages/fela-utils/src/objectSortByScore.js
+++ b/packages/fela-utils/src/objectSortByScore.js
@@ -1,8 +1,8 @@
 /* @flow */
 import arrayReduce from 'fast-loops/lib/arrayReduce'
+import objectReduce from 'fast-loops/lib/objectReduce'
 import findIndex from './findIndex'
 import insertAtIndex from './insertAtIndex'
-import objectReduce from 'fast-loops/lib/objectReduce'
 
 // TODO: we can further improve this one
 export default function objectSortByScore(
@@ -12,9 +12,7 @@ export default function objectSortByScore(
   const sortedKeys = objectReduce(
     obj,
     (resultSortedKeys, value, key) => {
-      const index = findIndex(resultSortedKeys, el => {
-        return getScore(obj[el], el) > getScore(value, key)
-      })
+      const index = findIndex(resultSortedKeys, el => getScore(obj[el], el) > getScore(value, key))
 
       if (index !== -1) {
         return insertAtIndex(resultSortedKeys, key, index)


### PR DESCRIPTION
…ndex'

We use Fela on our site and it's breaking in Windows IE11 because, IE11 does not support findIndex.

<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Add a description here.

## Example
If required, add a code example or a link to a working example (repository).

```javascript
// your code 
```

## Packages
List all packages that have been changed.

- 

## Versioning
None / Patch / Minor / Major

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [ ] The code has no linting errors (`yarn run lint`)
Unrelated
/Users/Megan.Smith/fela/packages/fela-codemods/src/v10/FelaComponent.js
  60:15  warning  Unexpected console statement  no-console
  96:15  warning  Unexpected console statement  no-console
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [ ] Documentation has been added/updated
- [ ] My changes have proper flow-types

