### PR TITLE
Update some typescript definitions

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -201,6 +201,12 @@ declare module "fela-utils" {
   export const CLEAR_TYPE: TClearType
 }
 
+declare module "fela-sort-media-query-mobile-first" {
+  import { TEnhancer } from "fela";
+
+  export default function(): TEnhancer;
+}
+
 /**
  * PLUGINS
  */
@@ -309,9 +315,9 @@ declare module "fela-plugin-simulate" {
 declare module "fela-plugin-unit" {
   import { TPlugin } from "fela";
 
-  type Unit = "ch" | "em" | "ex" | "rem" | "vh" | "vw" | "vmin" | "vmax" | "px" | "cm" | "mm" | "in" | "pc" | "pt" | "mozmm";
+  export type Unit = "ch" | "em" | "ex" | "rem" | "vh" | "vw" | "vmin" | "vmax" | "px" | "cm" | "mm" | "in" | "pc" | "pt" | "mozmm";
 
-  interface UnitPerProperty {
+  export interface UnitPerProperty {
     [key: string]: string;
   }
 
@@ -339,6 +345,15 @@ declare module "fela-plugin-validator" {
  */
 declare module "fela-preset-web" {
   import { TPlugin } from "fela";
+  import { Unit, UnitPerProperty } from "fela-plugin-unit";
+
+  type UnitConfig1 = [Unit]
+  type UnitConfig2 = [Unit, UnitPerProperty]
+  type UnitConfig3 = [Unit, UnitPerProperty, (property: string) => boolean]
+
+  type UnitConfig = UnitConfig1 | UnitConfig2 | UnitConfig3
+
+  export function createWebPreset({ unit }: { unit?: UnitConfig }): TPlugin[];
 
   const presets: TPlugin[];
   export default presets;


### PR DESCRIPTION
## Description
- Add missing definition for `fela-sort-media-query-mobile-first` enhancer
- Update `fela-preset-web` definition to add `createWebPreset` export function


## Example
If required, add a code example or a link to a working example (repository).

N/A

## Packages
List all packages that have been changed.

- `fela`

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

