### PR TITLE
Fix Plugin and Fela-Tools peerDependency Version Warnings

### DIFF
--- a/packages/fela-plugin-custom-property/package.json
+++ b/packages/fela-plugin-custom-property/package.json
@@ -27,7 +27,7 @@
     "isobject": "^3.0.1"
   },
   "peerDependencies": {
-    "fela": "^10.0.0"
+    "fela": "^11.2.0"
   },
   "gitHead": "e1a48f5d72623a0f95084dc07998dd85aa175bd1"
 }

--- a/packages/fela-plugin-extend/package.json
+++ b/packages/fela-plugin-extend/package.json
@@ -21,7 +21,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "peerDependencies": {
-    "fela": "^10.0.0"
+    "fela": "^11.2.0"
   },
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-plugin-native-media-query/package.json
+++ b/packages/fela-plugin-native-media-query/package.json
@@ -23,7 +23,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "peerDependencies": {
-    "fela-native": "^10.0.0",
+    "fela-native": "^11.2.0",
     "react": "*",
     "react-native": "*"
   },

--- a/packages/fela-plugin-simulate/package.json
+++ b/packages/fela-plugin-simulate/package.json
@@ -23,7 +23,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "peerDependencies": {
-    "fela": "^10.0.0"
+    "fela": "^11.2.0"
   },
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-plugin-typescript/package.json
+++ b/packages/fela-plugin-typescript/package.json
@@ -24,7 +24,7 @@
   "author": "Sergei Grishchenko <s.i.grishchenko@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "fela": "^10.0.0"
+    "fela": "^11.2.0"
   },
   "dependencies": {
     "isobject": "^3.0.1"

--- a/packages/fela-tools/package.json
+++ b/packages/fela-tools/package.json
@@ -21,7 +21,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "peerDependencies": {
-    "fela": "^10.0.0"
+    "fela": "^11.2.0"
   },
   "dependencies": {
     "css-in-js-utils": "^3.0.0",


### PR DESCRIPTION
## Description
Fixes `has incorrect peer dependency "fela@^10.0.0"` warnings

## Packages
fela-plugin-custom-property
fela-plugin-extend
fela-plugin-native-media-query
fela-plugin-simulate
fela-plugin-typescript
fela-tools

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

