### PR TITLE
Add ThemeContext to TypeScript typedef

### DIFF
--- a/packages/react-fela/index.d.ts
+++ b/packages/react-fela/index.d.ts
@@ -29,6 +29,8 @@ declare module "react-fela" {
    */
   export class FelaTheme extends React.Component<FelaThemeProps, {}> {}
 
+  export const ThemeContext: React.Context<object>
+
   interface ProviderProps {
     renderer: object;
   }


### PR DESCRIPTION
## Description
Adds `ThemeProvider` export to the `react-fela` TypeScript typedef; it already appears in `index.js`. 

The `index.d.ts`'s `ThemeProviderProps` and `FelaThemeProps` definitions both reference a `Theme` as having the type `object`, I maintained that choice. 

## Example
#### TypeScript Error
<img width="510" alt="TypeScript Error" src="https://user-images.githubusercontent.com/946726/78820961-a8198c00-79a6-11ea-9e6a-11643d2730ac.png">

#### index.js
<img width="534" alt="JavaScript Index File" src="https://user-images.githubusercontent.com/946726/78820962-a94ab900-79a6-11ea-84bd-0dee7ab3173e.png">

## Packages
- react-fela

## Versioning
Patch

## Checklist

#### Quality Assurance
- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types