### PR TITLE
Fix broken links on createComponent page

### DIFF
--- a/docs/api/bindings/createComponent.md
+++ b/docs/api/bindings/createComponent.md
@@ -7,7 +7,7 @@ It automatically composes rules and passed props for nested Fela components.
 ## Arguments
 | Argument | Type | Default | Description |
 | --- | --- | --- | --- |
-| rule | *Function*<br>*Object* |  | Either a [style object](../basics/Rules.md#styleobject) or rule function which satisfies the [rule](../basics/Rules.md) behavior and returns a valid [style object](../basics/Rules.md#styleobject). |
+| rule | *Function*<br>*Object* |  | Either a [style object](../../basics/Rules.md#style-object) or rule function which satisfies the [rule](../../basics/Rules.md) behavior and returns a valid [style object](../../basics/Rules.md#style-object). |
 | type | *string?*<br>*[Component](https://facebook.github.io/react/docs/top-level-api.html#react.component)?* | `div` | Component or HTML element which is used as the render base element.<br>**Note**: If a Component is passed, then it receives a className property. |
 | passThroughProps | *Array?*<br>*Function?* | | A list of props that get passed to the underlying element.<br>Alternatively a function of `props` that returns an array of prop names. |
 


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
I assume these links were meant to link to the rules page in the "Basics" section.

## Versioning
None

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Documentation has been added/updated

