### PR TITLE
Fix combineRules with undefined rule

### DIFF
--- a/packages/fela/src/combineRules.js
+++ b/packages/fela/src/combineRules.js
@@ -31,7 +31,7 @@ export default function combineRules(
         const resolvedRule = resolveRule(rule, props, renderer)
 
         // special combination of our special _className key
-        if (style._className) {
+        if (resolvedRule && style._className) {
           resolvedRule._className =
             style._className +
             (resolvedRule._className ? ' ' + resolvedRule._className : '')


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Fixes an issue where undefined rules caused a crash with `combineRules`.

## Packages
- fela 

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

