### PR TITLE
docs(fallback): improve example

### DIFF
--- a/packages/fela-plugin-fallback-value/README.md
+++ b/packages/fela-plugin-fallback-value/README.md
@@ -30,20 +30,20 @@ const renderer = createRenderer({
 #### Input
 ```javascript
 {
-  color: [ 'rgba(0, 0, 0, 0.5)', '#ccc']
+  color: [ '#ccc', 'rgba(0, 0, 0, 0.5)' ]
 }
 ```
 #### Output
 ```javascript
 {
-  color: 'rgba(0, 0, 0, 0.5);color:#ccc'
+  color: 'color:#ccc;rgba(0, 0, 0, 0.5);'
 }
 ```
 which is similar to the following CSS code:
 ```CSS
 {
+	color: #ccc;
 	color: rgba(0, 0, 0, 0.5);
-	color: #ccc
 }
 ```
 

--- a/packages/fela-plugin-fallback-value/README.md
+++ b/packages/fela-plugin-fallback-value/README.md
@@ -36,7 +36,7 @@ const renderer = createRenderer({
 #### Output
 ```javascript
 {
-  color: 'color:#ccc;rgba(0, 0, 0, 0.5);'
+  color: '#ccc;rgba(0, 0, 0, 0.5);'
 }
 ```
 which is similar to the following CSS code:


### PR DESCRIPTION
I think the rules in the readme of `fela-plugin-fallback-value` should be swapped to show a real-world example and have `#ccc` be fallback if `rgba` isn't supported in the browser.
Please correct me if I'm wrong, or misunderstand the purpose.

For reference: https://modernweb.com/using-css-fallback-properties-for-better-cross-browser-compatibility/

