### PR TITLE
Allow null in url strings

### DIFF
--- a/packages/fela-utils/src/isUndefinedValue.js
+++ b/packages/fela-utils/src/isUndefinedValue.js
@@ -3,6 +3,8 @@ export default function isUndefinedValue(value: any): boolean {
   return (
     value === undefined ||
     value === null ||
-    (typeof value === 'string' && value.match(/(undefined|null)/) !== null)
+    (typeof value === 'string' &&
+      value.match(/(undefined|null)/) !== null &&
+      value.match(/url/) === null)
   )
 }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This PR adds a special check for `url()` values since `null` and `undefined` could potentially be part of a Base64 string as seen in #772.

## Packages
List all packages that have been changed.

- fela-utils

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

