### PR TITLE
Add missing `return` to README for React example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,7 @@ const rule = state => ({
 const Button = ({ children, ...props }) => {
   const { css } = useFela(props)
   
-  <button className={css(rule)}>
-    {children}
-  </button>
+  return <button className={css(rule)}>{children}</button>;
 }
 
 const renderer = createRenderer()


### PR DESCRIPTION
Does what it says on the tin. I spotted this whilst trying to get Fela working on Codesandbox.