### PR TITLE
Removes warning from fonts with query strings

### DIFF
--- a/packages/fela/src/__tests__/getFontFormat-test.js
+++ b/packages/fela/src/__tests__/getFontFormat-test.js
@@ -22,4 +22,15 @@ describe('Checking the font format', () => {
       getFontFormat('data:image/png;base64,blahblahblahblahblahblah')
     ).toEqual('')
   })
+
+  it('should return the correct format for fonts with queries', () => {
+    expect(getFontFormat('foo.woff2?somequery')).toEqual('woff2')
+    expect(getFontFormat('foo.woff2?someq?uery')).toEqual('woff2')
+    expect(getFontFormat('foo.woff?someq?uery')).toEqual('woff')
+    expect(getFontFormat('foo.ttf?somequery')).toEqual('truetype')
+    expect(getFontFormat('foo.eot?somequery')).toEqual('embedded-opentype')
+    expect(getFontFormat('foo.otf?somequery')).toEqual('opentype')
+    expect(getFontFormat('foo.svg?somequery')).toEqual('svg')
+    expect(getFontFormat('foo.svgz?somequery')).toEqual('svg')
+  })
 })

--- a/packages/fela/src/getFontFormat.js
+++ b/packages/fela/src/getFontFormat.js
@@ -60,11 +60,19 @@ export default function getFontFormat(src: string): string {
       const c = src.charAt(i)
 
       if (c === '.') {
-        extension = c + extension
+        // fetches all the string from the gotten dot to the end
+        // of the string
+        const strippedSrc = src.slice(i, src.length)
+
+        // removes all query string that are usually attached to the
+        // font face strings e.g ./font-location/font.woff2?some-query
+        // Reference: https://github.com/robinweser/fela/issues/642
+        extension = strippedSrc.includes('?')
+          ? strippedSrc.split('?', 1)[0]
+          : strippedSrc
+
         break
       }
-
-      extension = c + extension
     }
 
     const fmt = formats[extension]

--- a/yarn.lock
+++ b/yarn.lock
@@ -12150,26 +12150,11 @@ minipass@^2.2.1, minipass@^2.3.4, minipass@^2.3.5:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minizlib@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.1.tgz#6734acc045a46e61d596a43bb9d9cd326e19cc42"
   dependencies:
     minipass "^2.2.1"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^1.2.0, mississippi@^1.3.0, mississippi@~1.3.0:
   version "1.3.1"
@@ -12605,22 +12590,6 @@ node-notifier@^5.0.1:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 node-pre-gyp@^0.10.0:
   version "0.10.3"
@@ -17261,19 +17230,6 @@ tar@^4, tar@^4.4.6:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
-
 temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
@@ -19232,11 +19188,6 @@ yallist@^2.0.0, yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
-
-yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This fixes an issue raised https://github.com/robinweser/fela/issues/642. Fonts with query string throws warnings

## Packages
List all packages that have been changed.
- fela

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated

