### PR TITLE
Adds rehydrate and targetDocument props to Provider

### DIFF
--- a/packages/preact-fela/index.d.ts
+++ b/packages/preact-fela/index.d.ts
@@ -64,6 +64,8 @@ declare module "preact-fela" {
 
   interface ProviderProps {
     renderer: object;
+    rehydrate?: boolean;
+    renderToDOM?: boolean;
   }
 
   interface FelaWithThemeProps<Theme> {

--- a/packages/react-fela/index.d.ts
+++ b/packages/react-fela/index.d.ts
@@ -33,6 +33,8 @@ declare module "react-fela" {
 
   interface ProviderProps {
     renderer: object;
+    rehydrate?: boolean;
+    targetDocument?: any;
   }
 
   interface FelaWithThemeProps<Theme> {


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This fixes this issue https://github.com/robinweser/fela/issues/787. We simply add the missing props to the typescript declaration

## Packages
List all packages that have been changed.
- react-fela
- preact-fela

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)
