### PR TITLE
Theme Value Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,19 +150,19 @@ render(
 If you are coming from CSS and want to learn JavaScript Styling with Fela, there is a full-feature [fela-workshop](https://github.com/tajo/fela-workshop) which demonstrates typical Fela use cases. It teaches all important parts, step by step with simple examples. If you already know other CSS in JS solutions and are just switching to Fela, you might not need to do the whole workshop, but it still provides useful information to get started quickly.
 
 ## Talks
-* [**CSS in JS: The Good & Bad Parts**](https://www.youtube.com/watch?v=95M-2YzyTno) ([Slides](https://speakerdeck.com/robinweser/css-in-js-the-good-and-bad-parts))<br> - *by [Robin Frischmann](https://twitter.com/robinweser)*
+* [**CSS in JS: The Good & Bad Parts**](https://www.youtube.com/watch?v=95M-2YzyTno) ([Slides](https://speakerdeck.com/robinweser/css-in-js-the-good-and-bad-parts))<br> - *by [Robin Weser](https://twitter.com/robinweser)*
 * [**CSS in JS: Patterns**](https://www.webexpo.net/prague2018/talk?id=css-in-js-patterns)<br> - *by [Vojtech Miksu](https://twitter.com/vmiksu)*
 
 ## Posts
-* [**Style as a Function of State**](https://medium.com/@robinweser/styles-as-functions-of-state-1885627a63f7#.6k6i4kdch)<br> - *by [Robin Frischmann](https://twitter.com/robinweser)*
+* [**Style as a Function of State**](https://medium.com/@robinweser/styles-as-functions-of-state-1885627a63f7#.6k6i4kdch)<br> - *by [Robin Weser](https://twitter.com/robinweser)*
 * [**CSS in JS: The Argument Refined**](https://medium.com/@steida/css-in-js-the-argument-refined-471c7eb83955#.3otvkubq4)<br> - *by [Daniel Steigerwald](https://twitter.com/steida)*
 * [**What is Fela?**](https://davidsinclair.io/thoughts/what-is-fela)<br> - *by [David Sinclair](https://davidsinclair.io)*
 * [**Choosing a CSS in JS library**](https://gist.github.com/troch/c27c6a8cc47b76755d848c6d1204fdaf#file-choosing-a-css-in-js-library-md)<br> - *by [Thomas Roch](https://twitter.com/tcroch)*
-* [**Introducing Fela 6.0**](https://medium.com/felajs/the-future-of-fela-d4dad2efad00)<br> - *by [Robin Frischmann](https://twitter.com/robinweser)*
+* [**Introducing Fela 6.0**](https://medium.com/felajs/the-future-of-fela-d4dad2efad00)<br> - *by [Robin Weser](https://twitter.com/robinweser)*
 * [**A journey into CSS and then into CSS-in-JS**](https://www.zeolearn.com/magazine/a-journey-into-css-and-then-into-css-in-js)<br> - *by [Prithvi Raju](https://twitter.com/aga5tya)*
 * [**CSS In JS — Future of styling components**](https://we-are.bookmyshow.com/css-in-js-future-of-styling-components-ad315eb5448b)<br> - *by [Manjula Dube](https://twitter.com/manjula_dube)*
 * [**Styling Components with React Fela**](https://alligator.io/react/styling-with-react-fela/)<br> - *by [Josh Sherman](https://twitter.com/joshtronic)*
-* [**The Future of Fela**](https://medium.com/@robinweser/introducing-fela-6-0-289c84b52dd5)<br> - *by [Robin Frischmann](https://twitter.com/robinweser)*
+* [**The Future of Fela**](https://medium.com/@robinweser/introducing-fela-6-0-289c84b52dd5)<br> - *by [Robin Weser](https://twitter.com/robinweser)*
 
 ## Ecosystem
 There are tons of useful packages maintained within this repository including plugins, enhancers, bindings and tools that can be used together with Fela. Check the [Ecosystem](http://fela.js.org/docs/introduction/Ecosystem.html) documentation for a quick overview.

--- a/book.json
+++ b/book.json
@@ -1,7 +1,7 @@
 {
   "gitbook": "3.1.0",
   "title": "Fela",
-  "author": "Robin Frischmann <robin@weser.io>",
+  "author": "Robin Weser <robin@weser.io>",
   "description": "Official documentation for Fela",
   "language": "en",
   "plugins": ["edit-link", "prism", "-highlight", "github", "anker-enable", "advanced-emoji"],

--- a/docs/advanced/Plugins.md
+++ b/docs/advanced/Plugins.md
@@ -42,11 +42,12 @@ Plugins are executed in the exact same order as provided. The output of the firs
 8. [fela-plugin-fallback-value](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-fallback-value)
 9. [fela-plugin-bidi](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-bidi)
 10. [fela-plugin-rtl](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-rtl)
-11. [fela-plugin-unit](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-unit)
-12. [fela-plugin-important](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-important)
-13. [fela-plugin-isolation](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-isolation)
-14. [fela-plugin-validator](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-validator)
-15. [fela-plugin-logger](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-logger)
+11. [fela-plugin-theme-value](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-theme-value)
+12. [fela-plugin-unit](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-unit)
+13. [fela-plugin-important](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-important)
+14. [fela-plugin-isolation](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-isolation)
+15. [fela-plugin-validator](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-validator)
+16. [fela-plugin-logger](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-logger)
 
 
 ## Custom Plugins

--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -46,6 +46,7 @@ Many plugins and enhancers are already included in the [main repository](https:/
 * [fela-plugin-unit](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-unit) - Automatically adds units to values if needed
 * [fela-plugin-validator*](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-validator) - Validates, logs & optionally deletes invalid properties for keyframes and rules
 * [fela-plugin-typescript](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-typescript) - Allows to write type-safe style rules and provides some autocomplete
+* [fela-plugin-theme-value](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-theme-value) - Resolves string-based theme values to actual style values
 
 #### Plugin-Presets
 * [fela-preset-web](https://github.com/robinweser/fela/tree/master/packages/fela-preset-web) - Preset for cross-browser web applications

--- a/docs/introduction/Motivation.md
+++ b/docs/introduction/Motivation.md
@@ -7,7 +7,7 @@ Then he introduced a complete new approach to handle those issues without any ac
 To make a long story short, soon after the talk, dozens of libraries grew on Github. Most of them were built directly for React while others were more open. <br>
 For a quick overview, check out [Michele Bertoli](https://twitter.com/MicheleBertoli)'s great  [css-in-js](https://github.com/MicheleBertoli/css-in-js) repository.
 
-Fela's creator, [Robin Frischmann](https://twitter.com/robinweser), also published a solution called [react-look](https://github.com/robinweser/react-look) himself. It was nicely accepted by the community and grew to a proud number of 550 stars at the time of writing this article.<br>
+Fela's creator, [Robin Weser](https://twitter.com/robinweser), also published a solution called [react-look](https://github.com/robinweser/react-look) himself. It was nicely accepted by the community and grew to a proud number of 550 stars at the time of writing this article.<br>
 Still he noticed that with each new feature and different use-case it would get more and more complicated to handle all the different components. He found that one of the major problems was the deep binding to React itself as well as the approach to satisfy **every** single use-case by providing numerous configuration options and several APIs.<br>
 
 After a long period of research and a lot gained experience with CSS in JS techniques, he created a whole new approach which became the library we now know as Fela.

--- a/examples/example-inferno/package.json
+++ b/examples/example-inferno/package.json
@@ -7,7 +7,7 @@
     "client": "NODE_ENV=development webpack-dev-server",
     "start": "concurrently --kill-others \"npm run client\" \"babel-node server.js\""
   },
-  "author": "Robin Frischmann <robin@weser.io>",
+  "author": "Robin Weser <robin@weser.io>",
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/examples/example-preact/package.json
+++ b/examples/example-preact/package.json
@@ -7,7 +7,7 @@
         "client": "NODE_ENV=development webpack-dev-server",
         "start": "concurrently --kill-others \"npm run client\" \"babel-node server.js\""
     },
-    "author": "Robin Frischmann <robin@weser.io>",
+    "author": "Robin Weser <robin@weser.io>",
     "license": "MIT",
     "devDependencies": {
         "babel-cli": "^6.24.1",

--- a/examples/example-react/package.json
+++ b/examples/example-react/package.json
@@ -7,7 +7,7 @@
         "client": "NODE_ENV=development webpack-dev-server",
         "start": "concurrently --kill-others \"npm run client\" \"babel-node server.js\""
     },
-    "author": "Robin Frischmann <robin@weser.io>",
+    "author": "Robin Weser <robin@weser.io>",
     "license": "MIT",
     "devDependencies": {
         "babel-cli": "^6.24.1",

--- a/packages/fela-beautifier/package.json
+++ b/packages/fela-beautifier/package.json
@@ -23,7 +23,7 @@
     "beautifier",
     "cssbeautify"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "cssbeautify": "^0.3.1",

--- a/packages/fela-bindings/package.json
+++ b/packages/fela-bindings/package.json
@@ -20,7 +20,7 @@
     "styling",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "fela": "*"

--- a/packages/fela-codemods/package.json
+++ b/packages/fela-codemods/package.json
@@ -21,7 +21,7 @@
     "styling",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-dom/package.json
+++ b/packages/fela-dom/package.json
@@ -25,7 +25,7 @@
     "styling",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-layout-debugger/package.json
+++ b/packages/fela-layout-debugger/package.json
@@ -20,7 +20,7 @@
     "debugger",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "styles-debugger": "^0.0.5"

--- a/packages/fela-logger/package.json
+++ b/packages/fela-logger/package.json
@@ -22,7 +22,7 @@
     "cssinjs",
     "logging"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "cssbeautify": "^0.3.1",

--- a/packages/fela-monolithic/package.json
+++ b/packages/fela-monolithic/package.json
@@ -21,7 +21,7 @@
     "devtools",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-native/package.json
+++ b/packages/fela-native/package.json
@@ -22,7 +22,7 @@
     "styling",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "fast-loops": "^1.0.0",

--- a/packages/fela-plugin-custom-property/package.json
+++ b/packages/fela-plugin-custom-property/package.json
@@ -20,7 +20,7 @@
     "mixin",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-plugin-embedded/package.json
+++ b/packages/fela-plugin-embedded/package.json
@@ -19,7 +19,7 @@
     "embedded",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "fast-loops": "^1.0.0",

--- a/packages/fela-plugin-expand-shorthand/package.json
+++ b/packages/fela-plugin-expand-shorthand/package.json
@@ -20,7 +20,7 @@
     "css-shorthands",
     "longhands"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "inline-style-expand-shorthand": "^1.2.0"

--- a/packages/fela-plugin-extend/package.json
+++ b/packages/fela-plugin-extend/package.json
@@ -18,7 +18,7 @@
     "fela-plugin",
     "extend"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "fela": "^11.2.0"

--- a/packages/fela-plugin-fallback-value/package.json
+++ b/packages/fela-plugin-fallback-value/package.json
@@ -19,7 +19,7 @@
     "fallback value",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-plugin-friendly-pseudo-class/package.json
+++ b/packages/fela-plugin-friendly-pseudo-class/package.json
@@ -19,7 +19,7 @@
     "fallback value",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "isobject": "^3.0.1"

--- a/packages/fela-plugin-important/package.json
+++ b/packages/fela-plugin-important/package.json
@@ -19,7 +19,7 @@
     "important",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "isobject": "^3.0.1"

--- a/packages/fela-plugin-isolation/package.json
+++ b/packages/fela-plugin-isolation/package.json
@@ -20,7 +20,7 @@
     "isolation",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "fast-loops": "^1.0.0"

--- a/packages/fela-plugin-logger/package.json
+++ b/packages/fela-plugin-logger/package.json
@@ -20,7 +20,7 @@
     "logging",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "gitHead": "4cc4686d9e16877251ac5c73e161076ec7c113a1"
 }

--- a/packages/fela-plugin-named-keys/package.json
+++ b/packages/fela-plugin-named-keys/package.json
@@ -20,7 +20,7 @@
     "supports",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-plugin-native-media-query/package.json
+++ b/packages/fela-plugin-native-media-query/package.json
@@ -20,7 +20,7 @@
     "media query",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "fela-native": "^11.2.0",

--- a/packages/fela-plugin-placeholder-prefixer/package.json
+++ b/packages/fela-plugin-placeholder-prefixer/package.json
@@ -21,7 +21,7 @@
     "autoprefixer",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "fast-loops": "^1.0.0",

--- a/packages/fela-plugin-prefixer/package.json
+++ b/packages/fela-plugin-prefixer/package.json
@@ -25,7 +25,7 @@
     "autoprefixer",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-plugin-responsive-value/package.json
+++ b/packages/fela-plugin-responsive-value/package.json
@@ -20,7 +20,7 @@
     "supports",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-plugin-rtl/package.json
+++ b/packages/fela-plugin-rtl/package.json
@@ -19,7 +19,7 @@
     "rtl",
     "accessibility"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "rtl-css-js": "^1.1.3"

--- a/packages/fela-plugin-simulate/package.json
+++ b/packages/fela-plugin-simulate/package.json
@@ -20,7 +20,7 @@
     "media query",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "fela": "^11.2.0"

--- a/packages/fela-plugin-theme-value/LICENSE
+++ b/packages/fela-plugin-theme-value/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Robin Weser
+Copyright (c) 2017-2020 Robin Weser
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/fela-plugin-theme-value/README.md
+++ b/packages/fela-plugin-theme-value/README.md
@@ -1,0 +1,92 @@
+# fela-plugin-theme-value
+
+<img alt="npm version" src="https://badge.fury.io/js/fela-plugin-theme-value.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-plugin-theme-value.svg"> <a href="https://bundlephobia.com/result?p=fela-plugin-theme-value@latest"><img alt="Bundlephobia" src="https://img.shields.io/bundlephobia/minzip/fela-plugin-theme-value.svg"></a>
+
+When creating consistent UI, a theme is mandatory too keep everything aligned. With built-in theme support, Fela made that possible from the very beginning.
+
+Yet, using values from the theme can be annoying since one has to access the theme manually and pick the correct values.<br>
+With tools like [theme-ui](https://theme-ui.com), a direct string based approach became very popular as it's easy too use and still easy to understand. 
+
+This plugin provides basic support for string-based theme values in Fela.
+
+## Installation
+```sh
+yarn add fela-plugin-theme-value
+```
+You may alternatively use `npm i --save fela-plugin-theme-value`.
+
+## Usage
+Make sure to read the documentation on [how to use plugins](http://fela.js.org/docs/advanced/Plugins.html).
+
+```javascript
+import { createRenderer } from 'fela'
+import themeValue from 'fela-plugin-theme-value'
+
+const renderer = createRenderer({
+  plugins: [ themeValue() ]
+})
+```
+
+### Configuration
+In order to get the right values from the theme, we have to pass an object that maps each property to the respective theme object.
+
+```javascript
+import { createRenderer } from 'fela'
+import themeValue from 'fela-plugin-theme-value'
+
+const themeMapping = {
+  color: theme => theme.colors,
+  backgroundColor: theme => theme.colors,
+  fontFamily: theme => theme.fonts
+}
+
+const themValuePlugin = themeValue(themeMapping)
+
+const renderer = createRenderer({
+  plugins: [ themValuePlugin ]
+})
+```
+
+## Example
+
+Let's imagine we have the following theme:
+```json
+{
+  colors: {
+    foreground: {
+      primary: "red",
+      secondary: "blue",
+    },
+    background: {
+      primary: "black",
+      secondary: "white",
+    }
+  },
+  fonts: {
+    text: "Helvetica Neue, Arial, sans-serif",
+    heading: "Impact, serif"
+  }
+}
+```
+
+#### Input
+```javascript
+{
+  color: "foreground.primary",
+  backgroundColor: "background.secondary",
+  fontFamily: "heading"
+}
+```
+#### Output
+```javascript
+{
+  color: "red",
+  backgroundColor: "white",
+  fontFamily: "Impact, serif"
+}
+```
+
+## License
+Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
+Documentation is licensed under [Creative Common License](http://creativecommons.org/licenses/by/4.0/).<br>
+Created with ♥ by [@robinweser](http://weser.io) and all the great contributors.

--- a/packages/fela-plugin-theme-value/package.json
+++ b/packages/fela-plugin-theme-value/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "fela-perf",
+  "name": "fela-plugin-theme-value",
   "version": "11.3.3",
-  "description": "Fela enhancer to log performance information",
+  "description": "Fela plugin to resolve values from a theme",
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
@@ -15,14 +15,20 @@
   "repository": "https://github.com/robinweser/fela/",
   "keywords": [
     "fela",
-    "fela-devtools",
-    "fela-enhancer",
-    "dx",
-    "devtools",
-    "cssinjs",
-    "performance"
+    "fela-plugin",
+    "theme",
+    "themed-ui",
+    "mixin",
+    "cssinjs"
   ],
   "author": "Robin Weser",
   "license": "MIT",
+  "dependencies": {
+    "css-in-js-utils": "^3.0.0",
+    "isobject": "^3.0.1"
+  },
+  "peerDependencies": {
+    "fela": "^11.2.0"
+  },
   "gitHead": "4cc4686d9e16877251ac5c73e161076ec7c113a1"
 }

--- a/packages/fela-plugin-theme-value/src/__tests__/customProperty-test.js
+++ b/packages/fela-plugin-theme-value/src/__tests__/customProperty-test.js
@@ -1,0 +1,64 @@
+import themeValue from '../index'
+
+const theme = {
+  colors: {
+    foreground: {
+      primary: 'red',
+      secondary: 'blue',
+    },
+    background: {
+      primary: 'black',
+      secondary: 'white',
+    },
+  },
+  fonts: {
+    text: 'Helvetica Neue, Arial, sans-serif',
+    heading: 'Impact, serif',
+  },
+}
+
+describe('Theme value plugin', () => {
+  it('should resolve theme values', () => {
+    const themeMapping = {
+      color: theme => theme.colors,
+      backgroundColor: theme => theme.colors,
+      fontFamily: theme => theme.fonts,
+    }
+
+    const style = {
+      color: 'foreground.primary',
+      backgroundColor: 'background.secondary',
+      fontFamily: 'heading',
+    }
+
+    expect(
+      themeValue(themeMapping)(style, undefined, undefined, { theme })
+    ).toEqual({
+      color: 'red',
+      backgroundColor: 'white',
+      fontFamily: 'Impact, serif',
+    })
+  })
+
+  it('should fallback to strings if no value is found', () => {
+    const themeMapping = {
+      color: theme => theme.colors,
+      backgroundColor: theme => theme.colors,
+      fontFamily: theme => theme.fonts,
+    }
+
+    const style = {
+      color: 'yellow',
+      backgroundColor: 'background.secondary',
+      fontFamily: 'Arial',
+    }
+
+    expect(
+      themeValue(themeMapping)(style, undefined, undefined, { theme })
+    ).toEqual({
+      color: 'yellow',
+      backgroundColor: 'white',
+      fontFamily: 'Arial',
+    })
+  })
+})

--- a/packages/fela-plugin-theme-value/src/__tests__/themeValue-test.js
+++ b/packages/fela-plugin-theme-value/src/__tests__/themeValue-test.js
@@ -20,9 +20,9 @@ const theme = {
 describe('Theme value plugin', () => {
   it('should resolve theme values', () => {
     const themeMapping = {
-      color: theme => theme.colors,
-      backgroundColor: theme => theme.colors,
-      fontFamily: theme => theme.fonts,
+      color: t => t.colors,
+      backgroundColor: t => t.colors,
+      fontFamily: t => t.fonts,
     }
 
     const style = {
@@ -42,9 +42,9 @@ describe('Theme value plugin', () => {
 
   it('should fallback to strings if no value is found', () => {
     const themeMapping = {
-      color: theme => theme.colors,
-      backgroundColor: theme => theme.colors,
-      fontFamily: theme => theme.fonts,
+      color: t => t.colors,
+      backgroundColor: t => t.colors,
+      fontFamily: t => t.fonts,
     }
 
     const style = {

--- a/packages/fela-plugin-theme-value/src/index.js
+++ b/packages/fela-plugin-theme-value/src/index.js
@@ -1,0 +1,45 @@
+/* @flow */
+import isPlainObject from 'isobject'
+
+import type { DOMRenderer } from '../../../flowtypes/DOMRenderer'
+import type { NativeRenderer } from '../../../flowtypes/NativeRenderer'
+import type { StyleType } from '../../../flowtypes/StyleType'
+
+function getValue(object, key) {
+  const value = key.split('.').reduce((value, key) => {
+    if (isPlainObject(value) && value[key]) {
+      return value[key]
+    }
+
+    return undefined
+  }, object)
+
+  return value || key
+}
+
+function resolveThemeValues(
+  style: Object,
+  theme: Object = {},
+  mapping: Object
+): Object {
+  for (const property in style) {
+    const value = style[property]
+
+    if (typeof value === 'string' && mapping[property]) {
+      style[property] = getValue(mapping[property](theme), value)
+    } else if (isPlainObject(value)) {
+      style[property] = resolveThemeValues(style[property], theme, mapping)
+    }
+  }
+
+  return style
+}
+
+export default function themeValue(mapping: Object = {}) {
+  return (
+    style: Object,
+    type: StyleType,
+    renderer: DOMRenderer | NativeRenderer,
+    props: Object
+  ): Object => resolveThemeValues(style, props.theme, mapping)
+}

--- a/packages/fela-plugin-unit/package.json
+++ b/packages/fela-plugin-unit/package.json
@@ -18,7 +18,7 @@
     "fela-plugin",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-plugin-validator/package.json
+++ b/packages/fela-plugin-validator/package.json
@@ -20,7 +20,7 @@
     "validator",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela-preset-dev/package.json
+++ b/packages/fela-preset-dev/package.json
@@ -18,7 +18,7 @@
     "fela-plugin",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "fela-plugin-logger": "^11.3.3",

--- a/packages/fela-preset-web/package.json
+++ b/packages/fela-preset-web/package.json
@@ -18,7 +18,7 @@
     "fela-plugin",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "fela-plugin-embedded": "^11.3.3",

--- a/packages/fela-sort-classnames/package.json
+++ b/packages/fela-sort-classnames/package.json
@@ -18,7 +18,7 @@
     "fela-enhancer",
     "sorting"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "gitHead": "4cc4686d9e16877251ac5c73e161076ec7c113a1"
 }

--- a/packages/fela-sort-media-query-mobile-first/LICENSE
+++ b/packages/fela-sort-media-query-mobile-first/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Robin Frischmann
+Copyright (c) 2017 Robin Weser
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/fela-sort-media-query-mobile-first/package.json
+++ b/packages/fela-sort-media-query-mobile-first/package.json
@@ -19,7 +19,7 @@
     "mobile-first",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "sort-css-media-queries": "^1.4.3"

--- a/packages/fela-statistics/package.json
+++ b/packages/fela-statistics/package.json
@@ -22,7 +22,7 @@
     "devtools",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "fela-tools": "^11.3.3",

--- a/packages/fela-tools/package.json
+++ b/packages/fela-tools/package.json
@@ -18,7 +18,7 @@
     "fela-tool",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "fela": "^11.2.0"

--- a/packages/fela-utils/package.json
+++ b/packages/fela-utils/package.json
@@ -18,7 +18,7 @@
     "fela-utils",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/fela/README.md
+++ b/packages/fela/README.md
@@ -150,19 +150,19 @@ render(
 If you are coming from CSS and want to learn JavaScript Styling with Fela, there is a full-feature [fela-workshop](https://github.com/tajo/fela-workshop) which demonstrates typical Fela use cases. It teaches all important parts, step by step with simple examples. If you already know other CSS in JS solutions and are just switching to Fela, you might not need to do the whole workshop, but it still provides useful information to get started quickly.
 
 ## Talks
-* [**CSS in JS: The Good & Bad Parts**](https://www.youtube.com/watch?v=95M-2YzyTno) ([Slides](https://speakerdeck.com/robinweser/css-in-js-the-good-and-bad-parts))<br> - *by [Robin Frischmann](https://twitter.com/robinweser)*
+* [**CSS in JS: The Good & Bad Parts**](https://www.youtube.com/watch?v=95M-2YzyTno) ([Slides](https://speakerdeck.com/robinweser/css-in-js-the-good-and-bad-parts))<br> - *by [Robin Weser](https://twitter.com/robinweser)*
 * [**CSS in JS: Patterns**](https://www.webexpo.net/prague2018/talk?id=css-in-js-patterns)<br> - *by [Vojtech Miksu](https://twitter.com/vmiksu)*
 
 ## Posts
-* [**Style as a Function of State**](https://medium.com/@robinweser/styles-as-functions-of-state-1885627a63f7#.6k6i4kdch)<br> - *by [Robin Frischmann](https://twitter.com/robinweser)*
+* [**Style as a Function of State**](https://medium.com/@robinweser/styles-as-functions-of-state-1885627a63f7#.6k6i4kdch)<br> - *by [Robin Weser](https://twitter.com/robinweser)*
 * [**CSS in JS: The Argument Refined**](https://medium.com/@steida/css-in-js-the-argument-refined-471c7eb83955#.3otvkubq4)<br> - *by [Daniel Steigerwald](https://twitter.com/steida)*
 * [**What is Fela?**](https://davidsinclair.io/thoughts/what-is-fela)<br> - *by [David Sinclair](https://davidsinclair.io)*
 * [**Choosing a CSS in JS library**](https://gist.github.com/troch/c27c6a8cc47b76755d848c6d1204fdaf#file-choosing-a-css-in-js-library-md)<br> - *by [Thomas Roch](https://twitter.com/tcroch)*
-* [**Introducing Fela 6.0**](https://medium.com/felajs/the-future-of-fela-d4dad2efad00)<br> - *by [Robin Frischmann](https://twitter.com/robinweser)*
+* [**Introducing Fela 6.0**](https://medium.com/felajs/the-future-of-fela-d4dad2efad00)<br> - *by [Robin Weser](https://twitter.com/robinweser)*
 * [**A journey into CSS and then into CSS-in-JS**](https://www.zeolearn.com/magazine/a-journey-into-css-and-then-into-css-in-js)<br> - *by [Prithvi Raju](https://twitter.com/aga5tya)*
 * [**CSS In JS — Future of styling components**](https://we-are.bookmyshow.com/css-in-js-future-of-styling-components-ad315eb5448b)<br> - *by [Manjula Dube](https://twitter.com/manjula_dube)*
 * [**Styling Components with React Fela**](https://alligator.io/react/styling-with-react-fela/)<br> - *by [Josh Sherman](https://twitter.com/joshtronic)*
-* [**The Future of Fela**](https://medium.com/@robinweser/introducing-fela-6-0-289c84b52dd5)<br> - *by [Robin Frischmann](https://twitter.com/robinweser)*
+* [**The Future of Fela**](https://medium.com/@robinweser/introducing-fela-6-0-289c84b52dd5)<br> - *by [Robin Weser](https://twitter.com/robinweser)*
 
 ## Ecosystem
 There are tons of useful packages maintained within this repository including plugins, enhancers, bindings and tools that can be used together with Fela. Check the [Ecosystem](http://fela.js.org/docs/introduction/Ecosystem.html) documentation for a quick overview.

--- a/packages/fela/package.json
+++ b/packages/fela/package.json
@@ -33,7 +33,7 @@
     "state-driven styling",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",

--- a/packages/inferno-fela/package.json
+++ b/packages/inferno-fela/package.json
@@ -23,7 +23,7 @@
     "styling",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "create-inferno-context": "^0.2.4",

--- a/packages/jest-fela-bindings/package.json
+++ b/packages/jest-fela-bindings/package.json
@@ -21,7 +21,7 @@
     "jest-utils",
     "jest-fela"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "dependencies": {
     "fela-tools": "^11.3.3",

--- a/packages/jest-inferno-fela/package.json
+++ b/packages/jest-inferno-fela/package.json
@@ -21,7 +21,7 @@
     "jest",
     "jest-utils"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "fela": "*",

--- a/packages/jest-preact-fela/package.json
+++ b/packages/jest-preact-fela/package.json
@@ -21,7 +21,7 @@
     "jest",
     "jest-utils"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "fela": "*",

--- a/packages/jest-react-fela/package.json
+++ b/packages/jest-react-fela/package.json
@@ -22,7 +22,7 @@
     "jest",
     "jest-utils"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "fela": "*",

--- a/packages/preact-fela/package.json
+++ b/packages/preact-fela/package.json
@@ -23,7 +23,7 @@
     "styling",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "preact": "^10.2.1"

--- a/packages/react-fela/package.json
+++ b/packages/react-fela/package.json
@@ -27,7 +27,7 @@
     "styling",
     "cssinjs"
   ],
-  "author": "Robin Frischmann",
+  "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
     "fela": "^11.3.1",


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This PR adds a new plugin: fela-plugin-theme-value.
It allows to use string-based theme value keys directly in style objects.

## Example
If required, add a code example or a link to a working example (repository).

```javascript
// given this theme
const theme = {
  colors: {
    foreground: {
      primary: "red",
      secondary: "blue"
    },
    background: {
      primary: "black",
      secondary: "white"
    }
  },
  fonts: {
    text: "Helvetica Neue, Arial, sanf-serif",
    heading: "Impact, serif"
  }
}

// with given plugin configuration
themeValue({
  color: theme => theme.colors,
  backgroundColors: theme => theme.colors,
  fontFamily: theme => theme.fonts
})

// one can now write style like this
const style = {
  color: "foreground.primary",
  backgroundColor: "background.secondary",
  fontFamily: "heading"
}
```

## Packages
List all packages that have been changed.

- fela-plugin-theme-value

## Versioning
Minor

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

