### PR TITLE
Add an option to allow prefixing CSS selectors

### DIFF
--- a/flowtypes/DOMRenderer.js
+++ b/flowtypes/DOMRenderer.js
@@ -5,6 +5,7 @@ export type DOMRenderer = {
   plugins: Array<Function>,
   sortMediaQuery: Function,
   selectorPrefix: string,
+  specifityPrefix: string,
   filterClassName: Function,
   listeners: Array<Function>,
   uniqueRuleIdentifier: number,
@@ -30,6 +31,7 @@ export type DOMRendererConfig = {
   styleNodeAttributes: Object,
   mediaQueryOrder?: Array<string>,
   selectorPrefix?: string,
+  specifityPrefix?: string,
   filterClassName?: Function,
   devMode?: boolean,
 }

--- a/flowtypes/DOMRenderer.js
+++ b/flowtypes/DOMRenderer.js
@@ -5,7 +5,7 @@ export type DOMRenderer = {
   plugins: Array<Function>,
   sortMediaQuery: Function,
   selectorPrefix: string,
-  specifityPrefix: string,
+  specificityPrefix: string,
   filterClassName: Function,
   listeners: Array<Function>,
   uniqueRuleIdentifier: number,
@@ -31,7 +31,7 @@ export type DOMRendererConfig = {
   styleNodeAttributes: Object,
   mediaQueryOrder?: Array<string>,
   selectorPrefix?: string,
-  specifityPrefix?: string,
+  specificityPrefix?: string,
   filterClassName?: Function,
   devMode?: boolean,
 }

--- a/packages/fela-dom/src/dom/__tests__/__snapshots__/rehydrate-test.js.snap
+++ b/packages/fela-dom/src/dom/__tests__/__snapshots__/rehydrate-test.js.snap
@@ -177,3 +177,92 @@ Array [
   },
 ]
 `;
+
+exports[`Rehydrating from DOM nodes should rehydrate the renderer cache 2`] = `
+Array [
+  10,
+  Object {
+    " #id > .foo ~ barbackgroundColorred": Object {
+      "className": "e",
+      "declaration": "background-color:red",
+      "media": "",
+      "pseudo": " #id > .foo ~ bar",
+      "selector": ".parentClass .e #id > .foo ~ bar",
+      "support": "",
+      "type": "RULE",
+    },
+    "(display: grid).foo.barcolorred": Object {
+      "className": "h",
+      "declaration": "color:red",
+      "media": "",
+      "pseudo": ".foo.bar",
+      "selector": ".parentClass .h.foo.bar",
+      "support": "(display: grid)",
+      "type": "RULE",
+    },
+    "(display: grid)colorblue": Object {
+      "className": "g",
+      "declaration": "color:blue",
+      "media": "",
+      "pseudo": "",
+      "selector": ".parentClass .g",
+      "support": "(display: grid)",
+      "type": "RULE",
+    },
+    ":hover> h1colorgreen": Object {
+      "className": "j",
+      "declaration": "color:green",
+      "media": "",
+      "pseudo": ":hover> h1",
+      "selector": ".parentClass .j:hover> h1",
+      "support": "",
+      "type": "RULE",
+    },
+    ":hovercolorred": Object {
+      "className": "i",
+      "declaration": "color:red",
+      "media": "",
+      "pseudo": ":hover",
+      "selector": ".parentClass .i:hover",
+      "support": "",
+      "type": "RULE",
+    },
+    "[alt=\\"Hello\\"]fontSize12px": Object {
+      "className": "f",
+      "declaration": "font-size:12px",
+      "media": "",
+      "pseudo": "[alt=\\"Hello\\"]",
+      "selector": ".parentClass .f[alt=\\"Hello\\"]",
+      "support": "",
+      "type": "RULE",
+    },
+    "backgroundColorred": Object {
+      "className": "c",
+      "declaration": "background-color:red",
+      "media": "",
+      "pseudo": "",
+      "selector": ".parentClass .c",
+      "support": "",
+      "type": "RULE",
+    },
+    "coloryellow": Object {
+      "className": "b",
+      "declaration": "color:yellow",
+      "media": "",
+      "pseudo": "",
+      "selector": ".parentClass .b",
+      "support": "",
+      "type": "RULE",
+    },
+    "flex1": Object {
+      "className": "d",
+      "declaration": "flex:1",
+      "media": "",
+      "pseudo": "",
+      "selector": ".parentClass .d",
+      "support": "",
+      "type": "RULE",
+    },
+  },
+]
+`;

--- a/packages/fela-dom/src/dom/__tests__/rehydrate-test.js
+++ b/packages/fela-dom/src/dom/__tests__/rehydrate-test.js
@@ -157,7 +157,7 @@ describe('Rehydrating from DOM nodes', () => {
   it('should rehydrate the renderer cache', () => {
     const serverRenderer = createRenderer({
       filterClassName: cls => cls !== 'a',
-      specifityPrefix: '.parentClass ',
+      specificityPrefix: '.parentClass ',
       plugins: [...webPreset],
     })
 
@@ -189,7 +189,7 @@ describe('Rehydrating from DOM nodes', () => {
 
     const clientRenderer = createRenderer({
       filterClassName: cls => cls !== 'a',
-      specifityPrefix: '.parentClass ',
+      specificityPrefix: '.parentClass ',
       plugins: [...webPreset],
     })
 

--- a/packages/fela-dom/src/dom/__tests__/rehydrate-test.js
+++ b/packages/fela-dom/src/dom/__tests__/rehydrate-test.js
@@ -153,4 +153,55 @@ describe('Rehydrating from DOM nodes', () => {
 
     expect(clientRenderer.uniqueRuleIdentifier).toBe(4)
   })
+
+  it('should rehydrate the renderer cache', () => {
+    const serverRenderer = createRenderer({
+      filterClassName: cls => cls !== 'a',
+      specifityPrefix: '.parentClass ',
+      plugins: [...webPreset],
+    })
+
+    serverRenderer.renderRule(() => ({
+      color: 'yellow',
+      backgroundColor: 'red',
+      flex: 1,
+      '& #id > .foo ~ bar': {
+        backgroundColor: 'red',
+      },
+      '[alt="Hello"]': {
+        fontSize: 12,
+      },
+      '@supports (display: grid)': {
+        color: 'blue',
+        '&.foo.bar': {
+          color: 'red',
+        },
+      },
+      ':hover': {
+        color: 'red',
+        '> h1': {
+          color: 'green',
+        },
+      },
+    }))
+
+    document.head.innerHTML = renderToMarkup(serverRenderer)
+
+    const clientRenderer = createRenderer({
+      filterClassName: cls => cls !== 'a',
+      specifityPrefix: '.parentClass ',
+      plugins: [...webPreset],
+    })
+
+    rehydrate(clientRenderer)
+
+    expect([
+      clientRenderer.uniqueRuleIdentifier,
+      clientRenderer.cache,
+    ]).toMatchSnapshot()
+
+    expect(sortObject(clientRenderer.cache)).toEqual(
+      sortObject(serverRenderer.cache)
+    )
+  })
 })

--- a/packages/fela-dom/src/dom/rehydrate.js
+++ b/packages/fela-dom/src/dom/rehydrate.js
@@ -44,7 +44,7 @@ export default function rehydrate(
             css,
             media,
             renderer.cache,
-            renderer.specifityPrefix
+            renderer.specificityPrefix
           )
         } else {
           rehydrateRules(
@@ -52,7 +52,7 @@ export default function rehydrate(
             media,
             '',
             renderer.cache,
-            renderer.specifityPrefix
+            renderer.specificityPrefix
           )
         }
 

--- a/packages/fela-dom/src/dom/rehydrate.js
+++ b/packages/fela-dom/src/dom/rehydrate.js
@@ -40,9 +40,20 @@ export default function rehydrate(
 
       if (type === RULE_TYPE) {
         if (support) {
-          rehydrateSupportRules(css, media, renderer.cache)
+          rehydrateSupportRules(
+            css,
+            media,
+            renderer.cache,
+            renderer.specifityPrefix
+          )
         } else {
-          rehydrateRules(css, media, '', renderer.cache)
+          rehydrateRules(
+            css,
+            media,
+            '',
+            renderer.cache,
+            renderer.specifityPrefix
+          )
         }
 
         // On Safari, style sheets with IE-specific media queries

--- a/packages/fela-dom/src/dom/rehydration/__tests__/__snapshots__/rehydrateRules-test.js.snap
+++ b/packages/fela-dom/src/dom/rehydration/__tests__/__snapshots__/rehydrateRules-test.js.snap
@@ -31,3 +31,35 @@ Object {
   },
 }
 `;
+
+exports[`Rehydrating rules should rehydrate the renderer cache with specifity prefix 1`] = `
+Object {
+  ":hover:activeborderColor2px solid rgb(255, 255, 0)": Object {
+    "className": "c",
+    "declaration": "border-color:2px solid rgb(255, 255, 0)",
+    "media": "",
+    "pseudo": ":hover:active",
+    "selector": ".parentClass .c:hover:active",
+    "support": "",
+    "type": "RULE",
+  },
+  "colorblue": Object {
+    "className": "b",
+    "declaration": "color:blue",
+    "media": "",
+    "pseudo": "",
+    "selector": ".parentClass .b",
+    "support": "",
+    "type": "RULE",
+  },
+  "colorred": Object {
+    "className": "a",
+    "declaration": "color:red",
+    "media": "",
+    "pseudo": "",
+    "selector": ".parentClass .a",
+    "support": "",
+    "type": "RULE",
+  },
+}
+`;

--- a/packages/fela-dom/src/dom/rehydration/__tests__/__snapshots__/rehydrateSupportRules-test.js.snap
+++ b/packages/fela-dom/src/dom/rehydration/__tests__/__snapshots__/rehydrateSupportRules-test.js.snap
@@ -31,3 +31,35 @@ Object {
   },
 }
 `;
+
+exports[`Rehydrating @supports rules should rehydrate the renderer cache with specifityPrefix 1`] = `
+Object {
+  "(display:grid) and (display:flex)colorgreen": Object {
+    "className": "c",
+    "declaration": "color:green",
+    "media": "",
+    "pseudo": "",
+    "selector": ".parentClass .c",
+    "support": "(display:grid) and (display:flex)",
+    "type": "RULE",
+  },
+  "(display:grid)colorblue": Object {
+    "className": "b",
+    "declaration": "color:blue",
+    "media": "",
+    "pseudo": "",
+    "selector": ".parentClass .b",
+    "support": "(display:grid)",
+    "type": "RULE",
+  },
+  "(display:grid)colorred": Object {
+    "className": "a",
+    "declaration": "color:red",
+    "media": "",
+    "pseudo": "",
+    "selector": ".parentClass .a",
+    "support": "(display:grid)",
+    "type": "RULE",
+  },
+}
+`;

--- a/packages/fela-dom/src/dom/rehydration/__tests__/rehydrateRules-test.js
+++ b/packages/fela-dom/src/dom/rehydration/__tests__/rehydrateRules-test.js
@@ -8,4 +8,15 @@ describe('Rehydrating rules', () => {
       )
     ).toMatchSnapshot()
   })
+  it('should rehydrate the renderer cache with specifity prefix', () => {
+    expect(
+      rehydrateRules(
+        '.parentClass .a{color:red}.parentClass .b{color:blue}.parentClass .c:hover:active{border-color:2px solid rgb(255, 255, 0)}',
+        '',
+        '',
+        {},
+        '.parentClass '
+      )
+    ).toMatchSnapshot()
+  })
 })

--- a/packages/fela-dom/src/dom/rehydration/__tests__/rehydrateSupportRules-test.js
+++ b/packages/fela-dom/src/dom/rehydration/__tests__/rehydrateSupportRules-test.js
@@ -8,4 +8,14 @@ describe('Rehydrating @supports rules', () => {
       )
     ).toMatchSnapshot()
   })
+  it('should rehydrate the renderer cache with specifityPrefix', () => {
+    expect(
+      rehydrateSupportRules(
+        '@supports(display:grid){.parentClass .a{color:red}.parentClass .b{color:blue}}@supports(display:grid) and (display:flex){.parentClass .c{color:green}}',
+        '',
+        {},
+        '.parentClass '
+      )
+    ).toMatchSnapshot()
+  })
 })

--- a/packages/fela-dom/src/dom/rehydration/generateCacheEntry.js
+++ b/packages/fela-dom/src/dom/rehydration/generateCacheEntry.js
@@ -11,12 +11,12 @@ export default function generateCacheEntry(
   pseudo?: string = '',
   media?: string = '',
   support?: string = '',
-  specifityPrefix?: string = ''
+  specificityPrefix?: string = ''
 ): Object {
   return {
     type,
     className,
-    selector: generateCSSSelector(className, pseudo, specifityPrefix),
+    selector: generateCSSSelector(className, pseudo, specificityPrefix),
     declaration: property + ':' + value,
     pseudo,
     media,

--- a/packages/fela-dom/src/dom/rehydration/generateCacheEntry.js
+++ b/packages/fela-dom/src/dom/rehydration/generateCacheEntry.js
@@ -10,12 +10,13 @@ export default function generateCacheEntry(
   value: any,
   pseudo?: string = '',
   media?: string = '',
-  support?: string = ''
+  support?: string = '',
+  specifityPrefix?: string = ''
 ): Object {
   return {
     type,
     className,
-    selector: generateCSSSelector(className, pseudo),
+    selector: generateCSSSelector(className, pseudo, specifityPrefix),
     declaration: property + ':' + value,
     pseudo,
     media,

--- a/packages/fela-dom/src/dom/rehydration/rehydrateRules.js
+++ b/packages/fela-dom/src/dom/rehydration/rehydrateRules.js
@@ -3,15 +3,23 @@ import { RULE_TYPE, generateDeclarationReference } from 'fela-utils'
 
 import generateCacheEntry from './generateCacheEntry'
 
-const DECL_REGEX = /[.]([0-9a-z_-]+)([^{]+)?{([^:]+):([^}]+)}/gi
+// Escaping for RegExp taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+function escapeRegExp(string) {
+  return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
+}
 
 export default function rehydrateRules(
   css: string,
   media: string = '',
   support?: string = '',
-  cache?: Object = {}
+  cache?: Object = {},
+  specifityPrefix?: string = ''
 ): Object {
   let decl
+  const DECL_REGEX = new RegExp(
+    `${escapeRegExp(specifityPrefix)}[.]([0-9a-z_-]+)([^{]+)?{([^:]+):([^}]+)}`,
+    'gi'
+  )
 
   // This excellent parsing implementation was originally taken from Styletron and modified to fit Fela
   // https://github.com/rtsao/styletron/blob/master/packages/styletron-client/src/index.js#L47
@@ -36,7 +44,8 @@ export default function rehydrateRules(
       value,
       pseudo,
       media,
-      support
+      support,
+      specifityPrefix
     )
   }
 

--- a/packages/fela-dom/src/dom/rehydration/rehydrateRules.js
+++ b/packages/fela-dom/src/dom/rehydration/rehydrateRules.js
@@ -13,11 +13,13 @@ export default function rehydrateRules(
   media: string = '',
   support?: string = '',
   cache?: Object = {},
-  specifityPrefix?: string = ''
+  specificityPrefix?: string = ''
 ): Object {
   let decl
   const DECL_REGEX = new RegExp(
-    `${escapeRegExp(specifityPrefix)}[.]([0-9a-z_-]+)([^{]+)?{([^:]+):([^}]+)}`,
+    `${escapeRegExp(
+      specificityPrefix
+    )}[.]([0-9a-z_-]+)([^{]+)?{([^:]+):([^}]+)}`,
     'gi'
   )
 
@@ -45,7 +47,7 @@ export default function rehydrateRules(
       pseudo,
       media,
       support,
-      specifityPrefix
+      specificityPrefix
     )
   }
 

--- a/packages/fela-dom/src/dom/rehydration/rehydrateSupportRules.js
+++ b/packages/fela-dom/src/dom/rehydration/rehydrateSupportRules.js
@@ -7,7 +7,8 @@ const SUPPORT_REGEX = /@supports[^{]+\{([\s\S]+?})\s*}/gi
 export default function rehydrateSupportRules(
   css: string,
   media?: string = '',
-  cache?: Object = {}
+  cache?: Object = {},
+  specifityPrefix?: string = ''
 ): Object {
   let decl
 
@@ -16,7 +17,7 @@ export default function rehydrateSupportRules(
     const [ruleSet, cssRules] = decl
 
     const supportQuery = extractSupportQuery(ruleSet)
-    rehydrateRules(cssRules, media, supportQuery, cache)
+    rehydrateRules(cssRules, media, supportQuery, cache, specifityPrefix)
   }
 
   return cache

--- a/packages/fela-dom/src/dom/rehydration/rehydrateSupportRules.js
+++ b/packages/fela-dom/src/dom/rehydration/rehydrateSupportRules.js
@@ -8,7 +8,7 @@ export default function rehydrateSupportRules(
   css: string,
   media?: string = '',
   cache?: Object = {},
-  specifityPrefix?: string = ''
+  specificityPrefix?: string = ''
 ): Object {
   let decl
 
@@ -17,7 +17,7 @@ export default function rehydrateSupportRules(
     const [ruleSet, cssRules] = decl
 
     const supportQuery = extractSupportQuery(ruleSet)
-    rehydrateRules(cssRules, media, supportQuery, cache, specifityPrefix)
+    rehydrateRules(cssRules, media, supportQuery, cache, specificityPrefix)
   }
 
   return cache

--- a/packages/fela-integration/src/fela_fela-tools/__tests__/__snapshots__/integration-test.js.snap
+++ b/packages/fela-integration/src/fela_fela-tools/__tests__/__snapshots__/integration-test.js.snap
@@ -4,6 +4,8 @@ exports[`Fela with Fela Tools integration Rendering keyframes should render dyna
 
 exports[`Fela with Fela Tools integration Rendering keyframes should render dynamic keyframe variations 2`] = `"@-webkit-keyframes k1{from{color:red}to{color:blue}}@-moz-keyframes k1{from{color:red}to{color:blue}}@keyframes k1{from{color:red}to{color:blue}}"`;
 
+exports[`Fela with Fela Tools integration Rendering rules should add specificity prefix 1`] = `".parent .a{color:red}"`;
+
 exports[`Fela with Fela Tools integration Rendering rules should prefix classNames 1`] = `".fela_a{color:red}"`;
 
 exports[`Fela with Fela Tools integration Rendering rules should prefix classNames 2`] = `"fela_a"`;
@@ -15,6 +17,8 @@ exports[`Fela with Fela Tools integration Rendering rules should remove undefine
 exports[`Fela with Fela Tools integration Rendering rules should render any nested selector with the &-prefix 1`] = `".a{color:red}.b~#foo{color:blue}.c .bar{color:green}"`;
 
 exports[`Fela with Fela Tools integration Rendering rules should render attribute selectors 1`] = `".a{color:red}.b[bool=true]{color:blue}"`;
+
+exports[`Fela with Fela Tools integration Rendering rules should render attribute selectors and add specificity prefix 1`] = `".parent .a{color:red}.parent .b[bool=true]{color:blue}"`;
 
 exports[`Fela with Fela Tools integration Rendering rules should render child selectors 1`] = `".a{color:red}.b>div{color:blue}"`;
 

--- a/packages/fela-integration/src/fela_fela-tools/__tests__/integration-test.js
+++ b/packages/fela-integration/src/fela_fela-tools/__tests__/integration-test.js
@@ -43,6 +43,18 @@ describe('Fela with Fela Tools integration', () => {
       expect(renderToString(renderer)).toMatchSnapshot()
       expect(className).toMatchSnapshot()
     })
+    it('should add specificity prefix', () => {
+      const rule = () => ({
+        color: 'red',
+      })
+
+      const renderer = createRenderer({
+        specificityPrefix: '.parent ',
+      })
+      const className = renderer.renderRule(rule)
+
+      expect(renderToString(renderer)).toMatchSnapshot()
+    })
 
     it('should render attribute selectors', () => {
       const rule = () => ({
@@ -52,6 +64,19 @@ describe('Fela with Fela Tools integration', () => {
         },
       })
       const renderer = createRenderer()
+
+      renderer.renderRule(rule)
+
+      expect(renderToString(renderer)).toMatchSnapshot()
+    })
+    it('should render attribute selectors and add specificity prefix', () => {
+      const rule = () => ({
+        color: 'red',
+        '[bool=true]': {
+          color: 'blue',
+        },
+      })
+      const renderer = createRenderer({ specificityPrefix: '.parent ' })
 
       renderer.renderRule(rule)
 

--- a/packages/fela-monolithic/src/__tests__/monolithic-test.js
+++ b/packages/fela-monolithic/src/__tests__/monolithic-test.js
@@ -140,12 +140,12 @@ describe('Monolithic enhancer', () => {
 
     const renderer = createRenderer({
       selectorPrefix: 'fela_',
-      specificityPrefix: '[class|="_fela"]',
+      specificityPrefix: '[class|="fela_"]',
     })
     const className = renderer.renderRule(rule)
 
     expect(renderToString(renderer)).toEqual(
-      `[class|="_fela"].${className}{color:red}`
+      `[class|="fela_"].${className}{color:red}`
     )
     expect(className).toContain('fela_')
   })
@@ -190,13 +190,13 @@ describe('Monolithic enhancer', () => {
     })
     const renderer = createRenderer({
       ...options,
-      specificityPrefix: '[class|="_fela"]',
+      specificityPrefix: '#app ',
     })
 
     const className = renderer.renderRule(rule)
 
     expect(renderToString(renderer)).toEqual(
-      `[class|="_fela"].${className}>div{color:blue}[class|="_fela"].${className}{color:red}`
+      `#app .${className}>div{color:blue}#app .${className}{color:red}`
     )
   })
 

--- a/packages/fela-monolithic/src/__tests__/monolithic-test.js
+++ b/packages/fela-monolithic/src/__tests__/monolithic-test.js
@@ -101,6 +101,24 @@ describe('Monolithic enhancer', () => {
       `.${className}{color:red}.${className}:hover{color:blue}`
     )
   })
+  it('should render pseudo classes, with specificityPrefix', () => {
+    const rule = () => ({
+      color: 'red',
+      ':hover': {
+        color: 'blue',
+      },
+    })
+
+    const renderer = createRenderer({
+      ...options,
+      specificityPrefix: '.parent ',
+    })
+    const className = renderer.renderRule(rule)
+
+    expect(renderToString(renderer)).toEqual(
+      `.parent .${className}{color:red}.parent .${className}:hover{color:blue}`
+    )
+  })
 
   it('should prefix classNames', () => {
     const rule = () => ({
@@ -113,6 +131,22 @@ describe('Monolithic enhancer', () => {
     const className = renderer.renderRule(rule)
 
     expect(renderToString(renderer)).toEqual(`.${className}{color:red}`)
+    expect(className).toContain('fela_')
+  })
+  it('should prefix classNames, and prefix selectors with specificityPrefix', () => {
+    const rule = () => ({
+      color: 'red',
+    })
+
+    const renderer = createRenderer({
+      selectorPrefix: 'fela_',
+      specificityPrefix: '[class|="_fela"]',
+    })
+    const className = renderer.renderRule(rule)
+
+    expect(renderToString(renderer)).toEqual(
+      `[class|="_fela"].${className}{color:red}`
+    )
     expect(className).toContain('fela_')
   })
 
@@ -145,6 +179,24 @@ describe('Monolithic enhancer', () => {
 
     expect(renderToString(renderer)).toEqual(
       `.${className}>div{color:blue}.${className}{color:red}`
+    )
+  })
+  it('should render child selectors, and prefix specificityPrefix', () => {
+    const rule = () => ({
+      color: 'red',
+      '>div': {
+        color: 'blue',
+      },
+    })
+    const renderer = createRenderer({
+      ...options,
+      specificityPrefix: '[class|="_fela"]',
+    })
+
+    const className = renderer.renderRule(rule)
+
+    expect(renderToString(renderer)).toEqual(
+      `[class|="_fela"].${className}>div{color:blue}[class|="_fela"].${className}{color:red}`
     )
   })
 

--- a/packages/fela-monolithic/src/index.js
+++ b/packages/fela-monolithic/src/index.js
@@ -85,7 +85,11 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
 
     if (Object.keys(ruleSet).length > 0) {
       const css = cssifyObject(ruleSet)
-      const selector = generateCSSSelector(className, pseudo)
+      const selector = generateCSSSelector(
+        className,
+        pseudo,
+        renderer.specifityPrefix
+      )
 
       const change = {
         type: RULE_TYPE,

--- a/packages/fela-monolithic/src/index.js
+++ b/packages/fela-monolithic/src/index.js
@@ -88,7 +88,7 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
       const selector = generateCSSSelector(
         className,
         pseudo,
-        renderer.specifityPrefix
+        renderer.specificityPrefix
       )
 
       const change = {

--- a/packages/fela-utils/src/__tests__/generateCSSSelector-test.js
+++ b/packages/fela-utils/src/__tests__/generateCSSSelector-test.js
@@ -4,5 +4,11 @@ describe('Generating css selectors', () => {
   it('should return a valid css selector', () => {
     expect(generateCSSSelector('foo')).toEqual('.foo')
     expect(generateCSSSelector('foo', ':hover')).toEqual('.foo:hover')
+    expect(generateCSSSelector('foo', ':hover', '.parent ')).toEqual(
+      '.parent .foo:hover'
+    )
+    expect(generateCSSSelector('foo', ':hover', '[class|="_SiteNav"]')).toEqual(
+      '[class|="_SiteNav"].foo:hover'
+    )
   })
 })

--- a/packages/fela-utils/src/generateCSSSelector.js
+++ b/packages/fela-utils/src/generateCSSSelector.js
@@ -2,7 +2,7 @@
 export default function generateCSSSelector(
   className: string,
   pseudo: string = '',
-  specifityPrefix?: string = ''
+  specificityPrefix?: string = ''
 ): string {
-  return `${specifityPrefix}.${className}${pseudo}`
+  return `${specificityPrefix}.${className}${pseudo}`
 }

--- a/packages/fela-utils/src/generateCSSSelector.js
+++ b/packages/fela-utils/src/generateCSSSelector.js
@@ -1,7 +1,8 @@
 /* @flow */
 export default function generateCSSSelector(
   className: string,
-  pseudo: string = ''
+  pseudo: string = '',
+  specifityPrefix?: string = ''
 ): string {
-  return `.${className}${pseudo}`
+  return `${specifityPrefix}.${className}${pseudo}`
 }

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -75,6 +75,7 @@ export default function createRenderer(
       /^:active/,
     ],
     selectorPrefix: validateSelectorPrefix(config.selectorPrefix),
+    specifityPrefix: config.specifityPrefix || '',
     filterClassName: config.filterClassName || isSafeClassName,
     devMode: config.devMode || false,
 
@@ -297,7 +298,11 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
               )
 
             const declaration = cssifyDeclaration(property, value)
-            const selector = generateCSSSelector(className, pseudo)
+            const selector = generateCSSSelector(
+              className,
+              pseudo,
+              config.specifityPrefix
+            )
 
             const change = {
               type: RULE_TYPE,

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -75,7 +75,7 @@ export default function createRenderer(
       /^:active/,
     ],
     selectorPrefix: validateSelectorPrefix(config.selectorPrefix),
-    specifityPrefix: config.specifityPrefix || '',
+    specificityPrefix: config.specificityPrefix || '',
     filterClassName: config.filterClassName || isSafeClassName,
     devMode: config.devMode || false,
 
@@ -301,7 +301,7 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
             const selector = generateCSSSelector(
               className,
               pseudo,
-              config.specifityPrefix
+              config.specificityPrefix
             )
 
             const change = {


### PR DESCRIPTION
#### This might not be a very requested use-case, but a very helpful feature nonetheless. We are managing a patched fela version which adds this feature for our use-case. Thought it would be nice to make it available for all if possible.
## Description
Adds a `specificityPrefix` configuration option to the renderer. This property prefixes every css rule with any valid css selector to increase specificity of all rules instead of relying on plugins like the `important-plugin`.
This is useful when using fela with other global css to control overrides, especially in places where the global css cannot be known beforehand.
Note: We cannot use an enhancer or a plugin since the selectors are not available in them.
## Example 1
```html
<div id="app"><!-- {{app}} --></div>
```
```javascript
  const renderer = createRenderer({
    plugins: [
      ...
    ],
    specificityPrefix:'#app '
  })
```
Now every css rule will be prefixed with the specificityPrefix `#app `:
```css
#app .a{
  color:red
}
#app .b{
  font-size:14px
}
```

## Example 2
Can also be mixed with `selectorPrefix`to increase specificity without relying on extra class names or ids, for example attribute selectors:
```html
<div id="app"><!-- {{app}} --></div>
```
```javascript
  const renderer = createRenderer({
    plugins: [
      ...
    ],
    selectorPrefix: '_fela',
    specificityPrefix: '[class|="_fela"]',
  })
```
Now every css rule will be prefixed with the specificityPrefix `[class|="_fela"]`:
```css
[class|="_fela"]._felaa{
  color:red
}
[class|="_fela"]._felab{
  font-size:14px
}
```
## Packages
- fela
- fela-dom
- fela-utils
- fela-monolithic
- fela-integration

## Versioning
Minor

## Checklist

#### Quality Assurance

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
- [x] Tests have been added/updated
- [ ] Documentation has been added/updated
- [x] My changes have proper flow-types

