### PR TITLE
feat: add `fela-plugin-fullscreen-prefixer`

### DIFF
--- a/packages/fela-plugin-fullscreen-prefixer/LICENSE
+++ b/packages/fela-plugin-fullscreen-prefixer/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017-2020 Robin Weser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/fela-plugin-fullscreen-prefixer/README.md
+++ b/packages/fela-plugin-fullscreen-prefixer/README.md
@@ -1,0 +1,62 @@
+# fela-plugin-fullscreen-prefixer
+
+<img alt="npm version" src="https://badge.fury.io/js/fela-plugin-fullscreen-prefixer.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-plugin-fullscreen-prefixer.svg"> <a href="https://bundlephobia.com/result?p=fela-plugin-fullscreen-prefixer@latest"><img alt="Bundlephobia" src="https://img.shields.io/bundlephobia/minzip/fela-plugin-fullscreen-prefixer.svg"></a>
+
+Adds prefixes to `:fullscreen` pseudo class.
+
+## Installation
+```sh
+yarn add fela-plugin-fullscreen-prefixer
+```
+You may alternatively use `npm i --save fela-plugin-fullscreen-prefixer`.
+
+
+## Usage
+Make sure to read the documentation on [how to use plugins](http://fela.js.org/docs/advanced/Plugins.html).
+
+```javascript
+import { createRenderer } from 'fela'
+import fullscreenPrefixer from 'fela-plugin-fullscreen-prefixer'
+
+const renderer = createRenderer({
+  plugins: [ fullscreenPrefixer() ]
+})
+```
+
+## Example
+
+#### Input
+```javascript
+{
+  color: 'red',
+  ':fullscreen': {
+    color: 'green'
+  }
+}
+```
+#### Output
+```javascript
+{
+  color: 'red',
+  ':-webkit-full-screen': {
+    color: 'green',
+  },
+  ':-moz-full-screen': {
+    color: 'green',
+  },
+  ':-ms-fullscreen': {
+    color: 'green',
+  },
+  ':full-screen': {
+    color: 'green',
+  },
+  ':fullscreen': {
+    color: 'green',
+  },
+}
+```
+
+## License
+Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
+Documentation is licensed under [Creative Common License](http://creativecommons.org/licenses/by/4.0/).<br>
+Created with ♥ by [@robinweser](http://weser.io) and all the great contributors.

--- a/packages/fela-plugin-fullscreen-prefixer/package.json
+++ b/packages/fela-plugin-fullscreen-prefixer/package.json
@@ -24,7 +24,6 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "fast-loops": "^1.0.0",
-    "fela-plugin-custom-property": "^11.3.3"
+    "fela-plugin-pseudo-prefixer": "^0.0.0"
   }
 }

--- a/packages/fela-plugin-fullscreen-prefixer/package.json
+++ b/packages/fela-plugin-fullscreen-prefixer/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "fela-plugin-fullscreen-prefixer",
+  "version": "0.0.0",
+  "description": "Fela plugin to add :fullscreen prefixes",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
+  "sideEffects": false,
+  "files": [
+    "LICENSE",
+    "README.md",
+    "lib/**",
+    "es/**"
+  ],
+  "repository": "https://github.com/robinweser/fela/",
+  "keywords": [
+    "fela",
+    "fela-plugin",
+    "vendor prefixing",
+    "prefixer",
+    "autoprefixer",
+    "cssinjs"
+  ],
+  "author": "Robin Frischmann",
+  "license": "MIT",
+  "dependencies": {
+    "fast-loops": "^1.0.0",
+    "fela-plugin-custom-property": "^11.3.3"
+  }
+}

--- a/packages/fela-plugin-fullscreen-prefixer/src/__tests__/fullscreenPrefixer-test.js
+++ b/packages/fela-plugin-fullscreen-prefixer/src/__tests__/fullscreenPrefixer-test.js
@@ -1,0 +1,31 @@
+import fullscreenPrefixer from '../index'
+
+describe('Fullscreen prefixer plugin', () => {
+  it('should add fullscreen prefixes', () => {
+    const style = {
+      width: 20,
+      ':fullscreen': {
+        color: 'red',
+      },
+    }
+
+    expect(fullscreenPrefixer()(style)).toEqual({
+      width: 20,
+      ':-webkit-full-screen': {
+        color: 'red',
+      },
+      ':-moz-full-screen': {
+        color: 'red',
+      },
+      ':-ms-fullscreen': {
+        color: 'red',
+      },
+      ':full-screen': {
+        color: 'red',
+      },
+      ':fullscreen': {
+        color: 'red',
+      },
+    })
+  })
+})

--- a/packages/fela-plugin-fullscreen-prefixer/src/index.js
+++ b/packages/fela-plugin-fullscreen-prefixer/src/index.js
@@ -1,0 +1,25 @@
+/* @flow */
+import customProperty from 'fela-plugin-custom-property'
+import arrayReduce from 'fast-loops/lib/arrayReduce'
+
+const fullscreenPrefixes = [
+  ':-webkit-full-screen',
+  ':-moz-full-screen',
+  ':-ms-fullscreen',
+  ':full-screen',
+  ':fullscreen',
+]
+
+export default function fullscreenPrefixer() {
+  return customProperty({
+    ':fullscreen': value =>
+      arrayReduce(
+        fullscreenPrefixes,
+        (style, prefix) => {
+          style[prefix] = value
+          return style
+        },
+        {}
+      ),
+  })
+}

--- a/packages/fela-plugin-fullscreen-prefixer/src/index.js
+++ b/packages/fela-plugin-fullscreen-prefixer/src/index.js
@@ -1,6 +1,5 @@
 /* @flow */
-import customProperty from 'fela-plugin-custom-property'
-import arrayReduce from 'fast-loops/lib/arrayReduce'
+import pseudoPrefixer from 'fela-plugin-pseudo-prefixer'
 
 const fullscreenPrefixes = [
   ':-webkit-full-screen',
@@ -11,15 +10,5 @@ const fullscreenPrefixes = [
 ]
 
 export default function fullscreenPrefixer() {
-  return customProperty({
-    ':fullscreen': value =>
-      arrayReduce(
-        fullscreenPrefixes,
-        (style, prefix) => {
-          style[prefix] = value
-          return style
-        },
-        {}
-      ),
-  })
+  return pseudoPrefixer(':fullscreen', fullscreenPrefixes)
 }

--- a/packages/fela-plugin-placeholder-prefixer/package.json
+++ b/packages/fela-plugin-placeholder-prefixer/package.json
@@ -24,8 +24,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "fast-loops": "^1.0.0",
-    "fela-plugin-custom-property": "^11.3.3"
+    "fela-plugin-pseudo-prefixer": "^0.0.0"
   },
   "gitHead": "4cc4686d9e16877251ac5c73e161076ec7c113a1"
 }

--- a/packages/fela-plugin-placeholder-prefixer/src/index.js
+++ b/packages/fela-plugin-placeholder-prefixer/src/index.js
@@ -1,6 +1,5 @@
 /* @flow */
-import customProperty from 'fela-plugin-custom-property'
-import arrayReduce from 'fast-loops/lib/arrayReduce'
+import pseudoPrefixer from 'fela-plugin-pseudo-prefixer'
 
 const placeholderPrefixes = [
   '::-webkit-input-placeholder',
@@ -11,15 +10,5 @@ const placeholderPrefixes = [
 ]
 
 export default function placeholderPrefixer() {
-  return customProperty({
-    '::placeholder': value =>
-      arrayReduce(
-        placeholderPrefixes,
-        (style, prefix) => {
-          style[prefix] = value
-          return style
-        },
-        {}
-      ),
-  })
+  return pseudoPrefixer('::placeholder', placeholderPrefixes)
 }

--- a/packages/fela-plugin-pseudo-prefixer/LICENSE
+++ b/packages/fela-plugin-pseudo-prefixer/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017-2020 Robin Weser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/fela-plugin-pseudo-prefixer/README.md
+++ b/packages/fela-plugin-pseudo-prefixer/README.md
@@ -1,0 +1,68 @@
+# fela-plugin-pseudo-prefixer
+
+<img alt="npm version" src="https://badge.fury.io/js/fela-plugin-pseudo-prefixer.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-plugin-pseudo-prefixer.svg"> <a href="https://bundlephobia.com/result?p=fela-plugin-pseudo-prefixer@latest"><img alt="Bundlephobia" src="https://img.shields.io/bundlephobia/minzip/fela-plugin-pseudo-prefixer.svg"></a>
+
+Adds prefixes to pseudo elements and classes.
+
+## Installation
+```sh
+yarn add fela-plugin-pseudo-prefixer
+```
+You may alternatively use `npm i --save fela-plugin-pseudo-prefixer`.
+
+
+## Usage
+Make sure to read the documentation on [how to use plugins](http://fela.js.org/docs/advanced/Plugins.html).
+
+```javascript
+import { createRenderer } from 'fela'
+import pseudoPrefixer from 'fela-plugin-pseudo-prefixer'
+
+const renderer = createRenderer({
+  plugins: [ pseudoPrefixer(':fullscreen', [
+    ':-webkit-full-screen',
+    ':-moz-full-screen',
+    ':-ms-fullscreen',
+    ':full-screen',
+    ':fullscreen',
+  ])
+})
+```
+
+## Example
+
+#### Input
+```javascript
+{
+  color: 'red',
+  ':fullscreen': {
+    color: 'green'
+  }
+}
+```
+#### Output
+```javascript
+{
+  color: 'red',
+  ':-webkit-full-screen': {
+    color: 'green',
+  },
+  ':-moz-full-screen': {
+    color: 'green',
+  },
+  ':-ms-fullscreen': {
+    color: 'green',
+  },
+  ':full-screen': {
+    color: 'green',
+  },
+  ':fullscreen': {
+    color: 'green',
+  },
+}
+```
+
+## License
+Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
+Documentation is licensed under [Creative Common License](http://creativecommons.org/licenses/by/4.0/).<br>
+Created with ♥ by [@robinweser](http://weser.io) and all the great contributors.

--- a/packages/fela-plugin-pseudo-prefixer/package.json
+++ b/packages/fela-plugin-pseudo-prefixer/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "fela-plugin-pseudo-prefixer",
+  "version": "0.0.0",
+  "description": "Fela plugin to add prefixes to pseudo elements and classes",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
+  "sideEffects": false,
+  "files": [
+    "LICENSE",
+    "README.md",
+    "lib/**",
+    "es/**"
+  ],
+  "repository": "https://github.com/robinweser/fela/",
+  "keywords": [
+    "fela",
+    "fela-plugin",
+    "vendor prefixing",
+    "prefixer",
+    "autoprefixer",
+    "cssinjs"
+  ],
+  "author": "Robin Frischmann",
+  "license": "MIT",
+  "dependencies": {
+    "fast-loops": "^1.0.0",
+    "fela-plugin-custom-property": "^11.3.3"
+  }
+}

--- a/packages/fela-plugin-pseudo-prefixer/src/__tests__/pseudoPrefixer-test.js
+++ b/packages/fela-plugin-pseudo-prefixer/src/__tests__/pseudoPrefixer-test.js
@@ -1,0 +1,39 @@
+import pseudoPrefixer from '../index'
+
+describe('Pseudo prefixer plugin', () => {
+  it('should add pseudo selector prefixes', () => {
+    const style = {
+      width: 20,
+      '::placeholder': {
+        color: 'red',
+      },
+    }
+
+    expect(
+      pseudoPrefixer('::placeholder', [
+        '::-webkit-input-placeholder',
+        '::-moz-placeholder',
+        ':-ms-input-placeholder',
+        ':-moz-placeholder',
+        '::placeholder',
+      ])(style)
+    ).toEqual({
+      width: 20,
+      '::-webkit-input-placeholder': {
+        color: 'red',
+      },
+      '::-moz-placeholder': {
+        color: 'red',
+      },
+      ':-ms-input-placeholder': {
+        color: 'red',
+      },
+      ':-moz-placeholder': {
+        color: 'red',
+      },
+      '::placeholder': {
+        color: 'red',
+      },
+    })
+  })
+})

--- a/packages/fela-plugin-pseudo-prefixer/src/index.js
+++ b/packages/fela-plugin-pseudo-prefixer/src/index.js
@@ -1,0 +1,17 @@
+/* @flow */
+import customProperty from 'fela-plugin-custom-property'
+import arrayReduce from 'fast-loops/lib/arrayReduce'
+
+export default function pseudoPrefixer(pseudoSelector, prefixes) {
+  return customProperty({
+    [pseudoSelector]: value =>
+      arrayReduce(
+        prefixes,
+        (style, prefix) => {
+          style[prefix] = value
+          return style
+        },
+        {}
+      ),
+  })
+}


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Add plugin for prefixing `:fullscreen` property. Pretty much copy of the `fela-plugin-placeholder-prefixer`

## Packages

- `fela-plugin-fullscreen-prefixer`

## Versioning
None? or Major?

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [ ] Documentation has been added/updated
- [ ] My changes have proper flow-types

