### PR TITLE
Fallback Fonts in fela-plugin-embedded

### DIFF
--- a/packages/fela-plugin-embedded/README.md
+++ b/packages/fela-plugin-embedded/README.md
@@ -5,12 +5,15 @@
 This plugins allows the use of inline keyframes and font-faces. It directly resolves them while rendering and only returns the correct reference.
 
 ## Installation
+
 ```sh
 yarn add fela-plugin-embedded
 ```
+
 You may alternatively use `npm i --save fela-plugin-embedded`.
 
 ## Usage
+
 Make sure to read the documentation on [how to use plugins](http://fela.js.org/docs/advanced/Plugins.html).
 
 ```javascript
@@ -18,12 +21,14 @@ import { createRenderer } from 'fela'
 import embedded from 'fela-plugin-embedded'
 
 const renderer = createRenderer({
-  plugins: [ embedded() ]
+  plugins: [embedded()],
 })
 ```
 
 ## Example
+
 #### Input
+
 ```javascript
 {
   width: '25px',
@@ -40,7 +45,9 @@ const renderer = createRenderer({
   }
 }
 ```
+
 #### Output
+
 ```javascript
 {
   width: '25px',
@@ -64,28 +71,40 @@ const renderer = createRenderer({
 
 ### Multiple font-faces
 
-```javascript
+```js
 {
-  fontFace: [{
+  fontFace: [
+    {
       fontFamily: 'Arial',
-      fontWeight: 400
-      src: [
-        'arial-regular.svg',
-        'arial-regular.ttf'
-      ]
+      fontWeight: 400,
+      src: ['arial-regular.svg', 'arial-regular.ttf'],
     },
     {
       fontFamily: 'Arial',
       fontWeight: 700,
-      src: [
-        'arial-bold.svg',
-        'arial-bold.ttf'
-      ]
-    }]
+      src: ['arial-bold.svg', 'arial-bold.ttf'],
+    },
+  ],
+}
+```
+
+### Fallback fonts
+
+```js
+{
+  fontFace: [
+    {
+      fontFamily: 'Arial',
+      fontWeight: 400,
+      src: ['arial.svg', 'arial.ttf'],
+    },
+    "sans-serif"
+  ],
 }
 ```
 
 ## License
+
 Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
 Documentation is licensed under [Creative Commons License](http://creativecommons.org/licenses/by/4.0/).<br>
 Created with ♥ by [@robinweser](http://weser.io) and all the great contributors.

--- a/packages/fela-plugin-embedded/src/__tests__/__snapshots__/embedded-test.js.snap
+++ b/packages/fela-plugin-embedded/src/__tests__/__snapshots__/embedded-test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`Embedded plugin should render base64 fonts 1`] = `"@font-face{font-weight:500;src:url(data:application/x-font-woff;charset=utf-8;base64,d09GRgABAAAAAHwwABMAAAAA4I) format('woff');font-family:\\"foo\\"}.a{font-family:\\"foo\\"}"`;
 
+exports[`Embedded plugin should render font string fallbacks 1`] = `"@font-face{font-weight:400;src:url('arial-regular.svg') format('svg'),url('arial-regular.ttf') format('truetype');font-family:\\"Arial\\"}.a{color:red}.b{font-family:\\"Arial\\",sans-serif}"`;
+
 exports[`Embedded plugin should render inline fonts with same fontFamily 1`] = `"@font-face{font-weight:400;src:url('arial-regular.svg') format('svg'),url('arial-regular.ttf') format('truetype');font-family:\\"Arial\\"}@font-face{font-weight:700;src:url('arial-bold.svg') format('svg'),url('arial-bold.ttf') format('truetype');font-family:\\"Arial\\"}.a{color:red}.b{font-family:\\"Arial\\"}"`;
 
 exports[`Embedded plugin should render inline keyframes & fonts 1`] = `"@font-face{font-weight:500;src:url('foo.svg') format('svg'),url('bar.ttf') format('truetype');font-family:\\"Arial\\"}@-webkit-keyframes k1{0%{color:red}100%{color:blue}}@-moz-keyframes k1{0%{color:red}100%{color:blue}}@keyframes k1{0%{color:red}100%{color:blue}}.a{color:red}.b{animation-name:k1}.c{font-family:\\"Arial\\"}"`;

--- a/packages/fela-plugin-embedded/src/__tests__/embedded-test.js
+++ b/packages/fela-plugin-embedded/src/__tests__/embedded-test.js
@@ -126,6 +126,27 @@ describe('Embedded plugin', () => {
     expect(renderToString(renderer)).toMatchSnapshot()
   })
 
+  it('should render font string fallbacks', () => {
+    const rule = () => ({
+      color: 'red',
+      fontFace: [
+        {
+          fontFamily: 'Arial',
+          src: ['arial-regular.svg', 'arial-regular.ttf'],
+          fontWeight: 400,
+        },
+        'sans-serif',
+      ],
+    })
+
+    const renderer = createRenderer({
+      plugins: [embedded()],
+    })
+    renderer.renderRule(rule)
+
+    expect(renderToString(renderer)).toMatchSnapshot()
+  })
+
   it('should render base64 fonts', () => {
     const rule = () => ({
       fontFace: {

--- a/packages/fela-plugin-embedded/src/index.js
+++ b/packages/fela-plugin-embedded/src/index.js
@@ -5,12 +5,18 @@ import isPlainObject from 'isobject'
 import type { DOMRenderer } from '../../../flowtypes/DOMRenderer'
 import type { StyleType } from '../../../flowtypes/StyleType'
 
-function renderFontFace({ fontFamily, src, ...otherProps }, renderer) {
+function renderFontFace(fontFace, renderer) {
+  if (typeof fontFace === 'string') {
+    return fontFace
+  }
+
+  const { fontFamily, src, ...otherProps } = fontFace
   if (typeof fontFamily === 'string' && Array.isArray(src)) {
     return renderer.renderFont(fontFamily, src, otherProps)
   }
 
   // TODO: warning - invalid font data
+
   return undefined
 }
 


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This PR adds support for string fallback fonts when using fela-plugin-embedded.

## Example
If required, add a code example or a link to a working example (repository).

```javascript
{
  fontFace: [
    {
      fontFamily: "Arial",
      src: [...]
    },  
    "sans-serif"
  ]
}
```

## Packages
List all packages that have been changed.

- fela-plugin-embedded

## Versioning
Minor

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

