### PR TITLE
Updated, csstype version 3

### DIFF
--- a/packages/fela/package.json
+++ b/packages/fela/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^3.0.0",
-    "csstype": "^2.5.5",
+    "csstype": "^3.0.5",
     "fast-loops": "^1.0.0",
     "fela-utils": "^11.5.0",
     "isobject": "^3.0.1"


### PR DESCRIPTION
## Description
This pull request just update csstype package version 2 to version 3. 

[issue](https://github.com/robinweser/fela/issues/835)

## Packages
List all packages that have been changed.
- "csstype": "^2.5.5", to "csstype": "^3.0.5",

