### PR TITLE
Remove Children.only from react-fela

### DIFF
--- a/packages/react-fela/src/RendererProvider.js
+++ b/packages/react-fela/src/RendererProvider.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { Component, Children, createElement } from 'react'
+import { Component, createElement } from 'react'
 import { RendererProviderFactory } from 'fela-bindings'
 import PropTypes from 'prop-types'
 
@@ -9,7 +9,7 @@ export default RendererProviderFactory(
   Component,
   RendererContext,
   createElement,
-  (children) => Children.only(children),
+  (children) => children,
   {
     propTypes: {
       renderer: PropTypes.object.isRequired,

--- a/packages/react-fela/src/ThemeProvider.js
+++ b/packages/react-fela/src/ThemeProvider.js
@@ -1,10 +1,12 @@
 /* @flow */
-import { createElement, Children } from 'react'
+import { createElement } from 'react'
 import { ThemeProviderFactory } from 'fela-bindings'
 import PropTypes from 'prop-types'
 
 import { ThemeContext } from './context'
 
-export default ThemeProviderFactory(ThemeContext, createElement, (children) =>
-  Children.only(children)
+export default ThemeProviderFactory(
+  ThemeContext,
+  createElement,
+  (children) => children
 )


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This PR simply removes the `Children.only` from react-fela so that multiple children can be passed.

## Packages
List all packages that have been changed.

- react-fela

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

