### PR TITLE
Allow React >= 16.3 for react-fela

### DIFF
--- a/packages/react-fela/package.json
+++ b/packages/react-fela/package.json
@@ -30,8 +30,8 @@
   "author": "Robin Weser",
   "license": "MIT",
   "peerDependencies": {
-    "fela": "^11.3.1",
-    "react": "^16.3.0"
+    "fela": ">= 11.3.1",
+    "react": ">= 16.3.0"
   },
   "dependencies": {
     "fela-bindings": "^11.5.2",


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This PR fixes the peerDependency definition on `react-fela` to allow for higher versions as well since npm seems to break with it.

## Packages
List all packages that have been changed.

- react-fela

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

