### PR TITLE
add missing ts-typing to `jest-react-fela` and `fela-plugin-fallback-value`

### DIFF
--- a/packages/fela-plugin-fallback-value/package.json
+++ b/packages/fela-plugin-fallback-value/package.json
@@ -10,6 +10,7 @@
   "files": [
     "LICENSE",
     "README.md",
+    "index.d.ts",
     "lib/**",
     "es/**"
   ],

--- a/packages/jest-react-fela/package.json
+++ b/packages/jest-react-fela/package.json
@@ -10,6 +10,7 @@
   "files": [
     "LICENSE",
     "README.md",
+    "index.d.ts",
     "lib/**",
     "es/**"
   ],


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Hi, 
as I was updating to a new fela-version and wanted to remove our type overwrite of jest-react-fela, I've found the following bug: index.d.ts wasn't added to the files array of jest-react-fela.

~~What I've missed yet, would be a check over _all_ packages, whether index.d.ts is existent in their files-arrays.~~ done

## Packages
List all packages that have been changed.

- jest-react-fela
- fela-plugin-fallback-value

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

