### PR TITLE
fela-plugin-prefixer: Handle CSS values with new lines

### DIFF
--- a/packages/fela-plugin-prefixer/src/__tests__/__snapshots__/prefixer-test.js.snap
+++ b/packages/fela-plugin-prefixer/src/__tests__/__snapshots__/prefixer-test.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Prefixer plugin handles css property values with line breaks correctly 1`] = `
+Object {
+  ":hover": Object {
+    "justifyContent": "center",
+  },
+  "WebkitBackgroundImage": "linear-gradient(90deg,
+      rgba(255,255,255, 0) 0,
+      red 40%,
+      red 60%,
+      rgba(255,255,255, 0)
+    );background-image:linear-gradient(90deg,
+      rgba(255,255,255, 0) 0,
+      red 40%,
+      red 60%,
+      rgba(255,255,255, 0)
+    )",
+  "display": "-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex",
+}
+`;
+
 exports[`Prefixer plugin should prefix nested objects 1`] = `
 Object {
   ":hover": Object {

--- a/packages/fela-plugin-prefixer/src/__tests__/prefixer-test.js
+++ b/packages/fela-plugin-prefixer/src/__tests__/prefixer-test.js
@@ -20,6 +20,22 @@ describe('Prefixer plugin', () => {
 
     expect(prefixer()(style)).toMatchSnapshot()
   })
+
+  it('handles css property values with line breaks correctly', () => {
+    const style = {
+      display: 'flex',
+      backgroundImage: `linear-gradient(90deg,
+      rgba(255,255,255, 0) 0,
+      red 40%,
+      red 60%,
+      rgba(255,255,255, 0)
+    )`,
+      ':hover': {
+        justifyContent: 'center',
+      },
+    }
+    expect(prefixer()(style)).toMatchSnapshot()
+  })
 })
 
 describe('Prefixer plugin (optimized)', () => {
@@ -45,6 +61,34 @@ describe('Prefixer plugin (optimized)', () => {
     ).toEqual({
       property: 'justifyContent',
       value: 'center',
+    })
+  })
+
+  it('handles css property values with line breaks correctly', () => {
+    const plugin = prefixer().optimized
+    expect(
+      plugin({
+        property: 'backgroundImage',
+        value: `linear-gradient(90deg,
+      rgba(255,255,255, 0) 0,
+      red 40%,
+      red 60%,
+      rgba(255,255,255, 0)
+    )`,
+      })
+    ).toEqual({
+      property: 'WebkitBackgroundImage',
+      value: `linear-gradient(90deg,
+      rgba(255,255,255, 0) 0,
+      red 40%,
+      red 60%,
+      rgba(255,255,255, 0)
+    );background-image:linear-gradient(90deg,
+      rgba(255,255,255, 0) 0,
+      red 40%,
+      red 60%,
+      rgba(255,255,255, 0)
+    )`,
     })
   })
 })

--- a/packages/fela-plugin-prefixer/src/index.js
+++ b/packages/fela-plugin-prefixer/src/index.js
@@ -14,7 +14,7 @@ function addVendorPrefixes(style) {
         const prefixed = stylisPrefix(cssDeclaration, property.length)
 
         if (prefixed !== cssDeclaration) {
-          const [property, value] = prefixed.split(/:(.+)/)
+          const [property, value] = prefixed.split(/:([\S\s]+)/)
           // TODO: do we really need to camelCase here?
           prefixedStyle[camelCaseProperty(property)] = value.slice(0, -1)
         } else {
@@ -33,7 +33,7 @@ addVendorPrefixes.optimized = (props) => {
   const prefixed = stylisPrefix(cssDeclaration, props.property.length)
 
   if (prefixed !== cssDeclaration) {
-    const [property, value] = prefixed.split(/:(.+)/)
+    const [property, value] = prefixed.split(/:([\S\s]+)/)
     // TODO: do we really need to camelCase here?
     props.property = camelCaseProperty(property)
     props.value = value.slice(0, -1)


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Fela-plugin-prefixer breaks when css property values have new lines in them, new line are valid in css.

## Example
```javascript
const style = {
      backgroundImage: `linear-gradient(90deg,
      rgba(255,255,255, 0) 0,
      red 40%,
      red 60%,
      rgba(255,255,255, 0)
    )`
    }
```
This currently transforms to the following due to only catching non-newline characters
```javascript
  { "WebkitBackgroundImage": "linear-gradient(90deg" }
```


## Packages

- fela-plugin-prefixer


## Versioning

Patch

## Checklist

#### Quality Assurance

> You can also run `pnpm run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`pnpm run format`)
- [x] The code has no linting errors (`pnpm run lint`)
- [x] All tests are passing (`pnpm run test`)

#### Changes

If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
