### PR TITLE
update bindings dependency for compare to move off version with node-fetch vulnerability

### DIFF
--- a/packages/fela-bindings/package.json
+++ b/packages/fela-bindings/package.json
@@ -42,7 +42,7 @@
     "fast-loops": "^1.0.0",
     "fela-dom": "^12.0.2",
     "fela-tools": "^12.0.2",
-    "react-addons-shallow-compare": "^15.6.2",
+    "react-addons-shallow-compare": "^15.6.3",
     "shallow-equal": "^1.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,7 +521,7 @@ importers:
       fela-tools: ^12.0.2
       jest: ^26.6.0
       react: ^17.0.2
-      react-addons-shallow-compare: ^15.6.2
+      react-addons-shallow-compare: ^15.6.3
       rimraf: ^3.0.0
       shallow-equal: ^1.0.0
     dependencies:
@@ -7918,6 +7918,7 @@ packages:
 
   /bindings/1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -10963,6 +10964,7 @@ packages:
 
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -15111,6 +15113,7 @@ packages:
 
   /nan/2.15.0:
     resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==}
+    requiresBuild: true
     dev: true
     optional: true
 


### PR DESCRIPTION
react-addons-shallow-compare 15.6.2 has a dependency on an old version of node-fetch with a known vulnerability