### PR TITLE
jest-react-fela | Fix createRoot support

### DIFF
--- a/packages/jest-react-fela/src/createSnapshot.js
+++ b/packages/jest-react-fela/src/createSnapshot.js
@@ -18,8 +18,8 @@ try {
 
 function renderComponent(component, node) {
   if (createRoot) {
-    const root = ReactDOMClient.createRoot(component)
-    root.render(node)
+    const root = createRoot(node)
+    root.render(component)
   } else {
     render(component, node)
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,15 +55,15 @@ importers:
       css-loader: ^3.4.2
       d3-scale-chromatic: 1.2.0
       fbjs: ^3.0.4
-      fela: ^12.0.2
-      fela-enforce-longhands: ^12.0.2
-      fela-preset-web: ^12.0.2
+      fela: ^12.1.0
+      fela-enforce-longhands: ^12.1.0
+      fela-preset-web: ^12.1.0
       glamor: ^2.20.40
       radium: ^0.26.0
       react: ^17.0.2
       react-art: ^17.0.0
       react-dom: ^17.0.2
-      react-fela: ^12.0.2
+      react-fela: ^12.1.0
       react-jss: ^10.0.4
       react-native-web: ^0.17.6
       reactxp: ^2.0.0
@@ -137,20 +137,20 @@ importers:
       cross-env: ^6.0.3
       express: ^4.14.0
       express-http-proxy: ^1.0.3
-      fela: ^12.0.2
-      fela-beautifier: ^12.0.2
-      fela-dom: ^12.0.2
-      fela-perf: ^12.0.2
-      fela-plugin-embedded: ^12.0.2
-      fela-plugin-fallback-value: ^12.0.2
-      fela-plugin-logger: ^12.0.2
+      fela: ^12.1.0
+      fela-beautifier: ^12.1.0
+      fela-dom: ^12.1.0
+      fela-perf: ^12.1.0
+      fela-plugin-embedded: ^12.1.0
+      fela-plugin-fallback-value: ^12.1.0
+      fela-plugin-logger: ^12.1.0
       fela-plugin-lvha: ^5.0.16
-      fela-plugin-prefixer: ^12.0.2
-      fela-plugin-unit: ^12.0.2
-      fela-plugin-validator: ^12.0.2
+      fela-plugin-prefixer: ^12.1.0
+      fela-plugin-unit: ^12.1.0
+      fela-plugin-validator: ^12.1.0
       inferno: ^6.1.5
       inferno-create-element: ^6.1.5
-      inferno-fela: ^12.0.2
+      inferno-fela: ^12.1.0
       inferno-server: ^6.1.5
       jest: ^26.6.0
       rimraf: ^3.0.0
@@ -209,22 +209,22 @@ importers:
       cross-env: ^6.0.3
       express: ^4.14.0
       express-http-proxy: ^1.0.3
-      fela: ^12.0.2
-      fela-beautifier: ^12.0.2
-      fela-dom: ^12.0.2
-      fela-layout-debugger: ^12.0.2
-      fela-perf: ^12.0.2
-      fela-plugin-embedded: ^12.0.2
-      fela-plugin-fallback-value: ^12.0.2
-      fela-plugin-logger: ^12.0.2
+      fela: ^12.1.0
+      fela-beautifier: ^12.1.0
+      fela-dom: ^12.1.0
+      fela-layout-debugger: ^12.1.0
+      fela-perf: ^12.1.0
+      fela-plugin-embedded: ^12.1.0
+      fela-plugin-fallback-value: ^12.1.0
+      fela-plugin-logger: ^12.1.0
       fela-plugin-lvha: ^5.0.16
-      fela-plugin-prefixer: ^12.0.2
-      fela-plugin-unit: ^12.0.2
-      fela-plugin-validator: ^12.0.2
-      fela-sort-media-query-mobile-first: ^12.0.2
+      fela-plugin-prefixer: ^12.1.0
+      fela-plugin-unit: ^12.1.0
+      fela-plugin-validator: ^12.1.0
+      fela-sort-media-query-mobile-first: ^12.1.0
       jest: ^26.6.0
       preact: ^10.2.1
-      preact-fela: ^12.0.2
+      preact-fela: ^12.1.0
       preact-render-to-string: ^3.6.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -281,23 +281,23 @@ importers:
       cross-env: ^6.0.3
       express: ^4.14.0
       express-http-proxy: ^1.0.3
-      fela: ^12.0.2
-      fela-beautifier: ^12.0.2
-      fela-dom: ^12.0.2
-      fela-layout-debugger: ^12.0.2
-      fela-perf: ^12.0.2
-      fela-plugin-embedded: ^12.0.2
-      fela-plugin-fallback-value: ^12.0.2
-      fela-plugin-logger: ^12.0.2
+      fela: ^12.1.0
+      fela-beautifier: ^12.1.0
+      fela-dom: ^12.1.0
+      fela-layout-debugger: ^12.1.0
+      fela-perf: ^12.1.0
+      fela-plugin-embedded: ^12.1.0
+      fela-plugin-fallback-value: ^12.1.0
+      fela-plugin-logger: ^12.1.0
       fela-plugin-lvha: ^5.0.16
-      fela-plugin-prefixer: ^12.0.2
-      fela-plugin-unit: ^12.0.2
-      fela-plugin-validator: ^12.0.2
-      fela-sort-media-query-mobile-first: ^12.0.2
+      fela-plugin-prefixer: ^12.1.0
+      fela-plugin-unit: ^12.1.0
+      fela-plugin-validator: ^12.1.0
+      fela-sort-media-query-mobile-first: ^12.1.0
       jest: ^26.6.0
       react: ^17.0.2
       react-dom: ^17.0.2
-      react-fela: ^12.0.2
+      react-fela: ^12.1.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
       webpack-cli: ^4.9.2
@@ -342,16 +342,16 @@ importers:
     specifiers:
       babel-preset-react-native: ^1.0.1
       create-react-native-app: ^0.0.6
-      fela: ^12.0.2
-      fela-dom: ^12.0.2
-      fela-native: ^12.0.2
-      fela-plugin-extend: ^12.0.2
-      fela-plugin-native-media-query: ^12.0.2
-      fela-tools: ^12.0.2
-      fela-utils: ^12.0.2
+      fela: ^12.1.0
+      fela-dom: ^12.1.0
+      fela-native: ^12.1.0
+      fela-plugin-extend: ^12.1.0
+      fela-plugin-native-media-query: ^12.1.0
+      fela-tools: ^12.1.0
+      fela-utils: ^12.1.0
       react: ^17.0.2
       react-dom: ^17.0.2
-      react-fela: ^12.0.2
+      react-fela: ^12.1.0
       react-native: 0.44.0
     devDependencies:
       babel-preset-react-native: 1.9.2
@@ -375,23 +375,23 @@ importers:
       '@babel/preset-env': ^7.4.2
       babel-loader: ^8.0.5
       dog-names: ^1.0.2
-      fela: ^12.0.2
-      fela-beautifier: ^12.0.2
+      fela: ^12.1.0
+      fela-beautifier: ^12.1.0
       fela-combine-arrays: ^1.0.9
-      fela-plugin-embedded: ^12.0.2
-      fela-plugin-friendly-pseudo-class: ^12.0.2
+      fela-plugin-embedded: ^12.1.0
+      fela-plugin-friendly-pseudo-class: ^12.1.0
       fela-plugin-named-media-query: ^5.0.13
-      fela-plugin-placeholder-prefixer: ^12.0.2
-      fela-plugin-unit: ^12.0.2
-      fela-plugin-validator: ^12.0.2
-      fela-preset-web: ^12.0.2
-      fela-statistics: ^12.0.2
+      fela-plugin-placeholder-prefixer: ^12.1.0
+      fela-plugin-unit: ^12.1.0
+      fela-plugin-validator: ^12.1.0
+      fela-preset-web: ^12.1.0
+      fela-statistics: ^12.1.0
       lodash: ^4.17.4
       polished: 1.9.0
       prop-types: ^15.5.10
       react: ^17.0.2
       react-dom: ^17.0.2
-      react-fela: ^12.0.2
+      react-fela: ^12.1.0
       react-modal: ^2.2.2
       react-styleguidist: 9.0.4
       webpack: 4.29.6
@@ -439,7 +439,7 @@ importers:
       css-in-js-utils: ^3.0.0
       csstype: ^3.0.5
       fast-loops: ^1.0.0
-      fela-utils: ^12.0.2
+      fela-utils: ^12.1.0
       isobject: ^3.0.1
       jest: ^26.6.0
       rimraf: ^3.0.0
@@ -516,9 +516,9 @@ importers:
       babel-jest: ^26.6.0
       cross-env: ^6.0.3
       fast-loops: ^1.0.0
-      fela: ^12.0.2
-      fela-dom: ^12.0.2
-      fela-tools: ^12.0.2
+      fela: ^12.1.0
+      fela-dom: ^12.1.0
+      fela-tools: ^12.1.0
       jest: ^26.6.0
       react: ^17.0.2
       react-addons-shallow-compare: ^15.6.3
@@ -558,10 +558,10 @@ importers:
       cross-env: ^6.0.3
       css-in-js-utils: ^3.0.0
       fast-loops: ^1.0.1
-      fela: ^12.0.2
-      fela-preset-web: ^12.0.2
-      fela-tools: ^12.0.2
-      fela-utils: ^12.0.2
+      fela: ^12.1.0
+      fela-preset-web: ^12.1.0
+      fela-tools: ^12.1.0
+      fela-utils: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
     dependencies:
@@ -599,10 +599,10 @@ importers:
       cross-env: ^6.0.3
       css-in-js-utils: ^3.0.0
       fast-loops: ^1.0.1
-      fela: ^12.0.2
-      fela-preset-web: ^12.0.2
-      fela-tools: ^12.0.2
-      fela-utils: ^12.0.2
+      fela: ^12.1.0
+      fela-preset-web: ^12.1.0
+      fela-tools: ^12.1.0
+      fela-utils: ^12.1.0
       jest: ^26.6.0
       js-beautify: ^1.14.0
       jsdom: ^16.6.0
@@ -650,7 +650,7 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela: ^12.0.2
+      fela: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -688,14 +688,14 @@ importers:
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
       fast-loops: ^1.0.0
-      fela: ^12.0.2
-      fela-monolithic: ^12.0.2
-      fela-tools: ^12.0.2
+      fela: ^12.1.0
+      fela-monolithic: ^12.1.0
+      fela-tools: ^12.1.0
       jest: ^26.6.0
-      jest-react-fela: ^12.0.2
+      jest-react-fela: ^12.1.0
       jsdom: ^16.6.0
       react: ^17.0.2
-      react-fela: ^12.0.2
+      react-fela: ^12.1.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
       webpack-cli: ^3.3.10
@@ -738,17 +738,17 @@ importers:
       babel-core: 7.0.0-bridge.0
       babel-jest: ^26.6.0
       cross-env: ^6.0.3
-      fela: ^12.0.2
-      fela-dom: ^12.0.2
-      fela-monolithic: ^12.0.2
-      fela-tools: ^12.0.2
+      fela: ^12.1.0
+      fela-dom: ^12.1.0
+      fela-monolithic: ^12.1.0
+      fela-tools: ^12.1.0
       jest: ^26.6.0
-      jest-react-fela: ^12.0.2
+      jest-react-fela: ^12.1.0
       jsdom: ^19.0.0
       raf: ^3.4.1
       react: ^17.0.2
       react-dom: ^17.0.2
-      react-fela: ^12.0.2
+      react-fela: ^12.1.0
       react-test-renderer: ^17.0.2
       rimraf: ^3.0.0
     dependencies:
@@ -790,7 +790,7 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela: ^12.0.2
+      fela: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
       styles-debugger: ^0.0.5
@@ -830,7 +830,7 @@ importers:
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
       cssbeautify: ^0.3.1
-      fela-utils: ^12.0.2
+      fela-utils: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -870,9 +870,9 @@ importers:
       cross-env: ^6.0.3
       css-in-js-utils: ^3.0.0
       fast-loops: ^1.0.0
-      fela: ^12.0.2
-      fela-tools: ^12.0.2
-      fela-utils: ^12.0.2
+      fela: ^12.1.0
+      fela-tools: ^12.1.0
+      fela-utils: ^12.1.0
       isobject: ^3.0.1
       jest: ^26.6.0
       rimraf: ^3.0.0
@@ -916,7 +916,7 @@ importers:
       babel-jest: ^26.6.0
       cross-env: ^6.0.3
       fast-loops: ^1.0.0
-      fela-utils: ^12.0.2
+      fela-utils: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
     dependencies:
@@ -1059,8 +1059,8 @@ importers:
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
       fast-loops: ^1.0.0
-      fela: ^12.0.2
-      fela-tools: ^12.0.2
+      fela: ^12.1.0
+      fela-tools: ^12.1.0
       isobject: ^3.0.1
       jest: ^26.6.0
       rimraf: ^3.0.0
@@ -1140,7 +1140,7 @@ importers:
       cross-env: ^6.0.3
       css-in-js-utils: ^3.0.0
       fast-loops: ^1.0.0
-      fela-utils: ^12.0.2
+      fela-utils: ^12.1.0
       isobject: ^3.0.1
       jest: ^26.6.0
       rimraf: ^3.0.0
@@ -1257,7 +1257,7 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela-plugin-pseudo-prefixer: ^12.0.2
+      fela-plugin-pseudo-prefixer: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -1335,7 +1335,7 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela-utils: ^12.0.2
+      fela-utils: ^12.1.0
       isobject: ^3.0.1
       jest: ^26.6.0
       rimraf: ^3.0.0
@@ -1562,7 +1562,7 @@ importers:
       cross-env: ^6.0.3
       css-in-js-utils: ^3.0.0
       css-mediaquery: ^0.1.2
-      fela-utils: ^12.0.2
+      fela-utils: ^12.1.0
       isobject: ^3.0.1
       jest: ^26.6.0
       react: ^17.0.2
@@ -1605,7 +1605,7 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela-plugin-pseudo-prefixer: ^12.0.2
+      fela-plugin-pseudo-prefixer: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -1686,7 +1686,7 @@ importers:
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
       fast-loops: ^1.0.0
-      fela-plugin-custom-property: ^12.0.2
+      fela-plugin-custom-property: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -1950,7 +1950,7 @@ importers:
       cross-env: ^6.0.3
       css-in-js-utils: ^3.0.0
       csslint: ^1.0.5
-      fela-utils: ^12.0.2
+      fela-utils: ^12.1.0
       isobject: ^3.0.1
       jest: ^26.6.0
       rimraf: ^3.0.0
@@ -1991,9 +1991,9 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela: ^12.0.2
-      fela-plugin-logger: ^12.0.2
-      fela-plugin-validator: ^12.0.2
+      fela: ^12.1.0
+      fela-plugin-logger: ^12.1.0
+      fela-plugin-validator: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -2032,13 +2032,13 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela: ^12.0.2
-      fela-plugin-embedded: ^12.0.2
-      fela-plugin-extend: ^12.0.2
-      fela-plugin-fallback-value: ^12.0.2
-      fela-plugin-prefixer: ^12.0.2
-      fela-plugin-unit: ^12.0.2
-      fela-tools: ^12.0.2
+      fela: ^12.1.0
+      fela-plugin-embedded: ^12.1.0
+      fela-plugin-extend: ^12.1.0
+      fela-plugin-fallback-value: ^12.1.0
+      fela-plugin-prefixer: ^12.1.0
+      fela-plugin-unit: ^12.1.0
+      fela-tools: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -2081,7 +2081,7 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela: ^12.0.2
+      fela: ^12.1.0
       jest: ^26.6.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -2153,8 +2153,8 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela-tools: ^12.0.2
-      fela-utils: ^12.0.2
+      fela-tools: ^12.1.0
+      fela-utils: ^12.1.0
       gzip-size: ^3.0.0
       rimraf: ^3.0.0
       webpack: ^4.41.6
@@ -2193,8 +2193,8 @@ importers:
       cross-env: ^6.0.3
       css-in-js-utils: ^3.0.0
       fast-loops: ^1.0.0
-      fela: ^12.0.2
-      fela-utils: ^12.0.2
+      fela: ^12.1.0
+      fela-utils: ^12.1.0
       jest: ^26.6.0
       js-beautify: ^1.14.0
       jsdom: ^16.6.0
@@ -2278,9 +2278,9 @@ importers:
       clean-webpack-plugin: ^3.0.0
       create-inferno-context: ^0.2.4
       cross-env: ^6.0.3
-      fela: ^12.0.2
-      fela-bindings: ^12.0.2
-      fela-dom: ^12.0.2
+      fela: ^12.1.0
+      fela-bindings: ^12.1.0
+      fela-dom: ^12.1.0
       inferno: ^5.0.1
       inferno-create-element: ^5.0.1
       jest: ^26.6.0
@@ -2322,7 +2322,7 @@ importers:
       babel-core: 7.0.0-bridge.0
       babel-jest: ^26.6.0
       cross-env: ^6.0.3
-      fela-tools: ^12.0.2
+      fela-tools: ^12.1.0
       htmltojsx: ^0.3.0
       jest: ^26.6.0
       rimraf: ^3.0.0
@@ -2352,7 +2352,7 @@ importers:
       '@babel/preset-env': ^7.5.5
       babel-core: 7.0.0-bridge.0
       cross-env: ^6.0.3
-      jest-fela-bindings: ^12.0.2
+      jest-fela-bindings: ^12.1.0
       rimraf: ^3.0.0
     dependencies:
       jest-fela-bindings: link:../jest-fela-bindings
@@ -2377,7 +2377,7 @@ importers:
       '@babel/preset-env': ^7.5.5
       babel-core: 7.0.0-bridge.0
       cross-env: ^6.0.3
-      jest-fela-bindings: ^12.0.2
+      jest-fela-bindings: ^12.1.0
       rimraf: ^3.0.0
     dependencies:
       jest-fela-bindings: link:../jest-fela-bindings
@@ -2402,11 +2402,11 @@ importers:
       '@babel/preset-env': ^7.5.5
       babel-core: 7.0.0-bridge.0
       cross-env: ^6.0.3
-      fela: ^12.0.2
-      fela-preset-web: ^12.0.2
-      jest-fela-bindings: ^12.0.2
+      fela: ^12.1.0
+      fela-preset-web: ^12.1.0
+      jest-fela-bindings: ^12.1.0
       react: ^17.0.2
-      react-fela: ^12.0.2
+      react-fela: ^12.1.0
       rimraf: ^3.0.0
     dependencies:
       jest-fela-bindings: link:../jest-fela-bindings
@@ -2435,9 +2435,9 @@ importers:
       '@babel/preset-env': ^7.5.5
       babel-core: 7.0.0-bridge.0
       cross-env: ^6.0.3
-      fela: ^12.0.2
-      fela-bindings: ^12.0.2
-      fela-dom: ^12.0.2
+      fela: ^12.1.0
+      fela-bindings: ^12.1.0
+      fela-dom: ^12.1.0
       preact: ^10.6.6
       rimraf: ^3.0.0
     dependencies:
@@ -2468,9 +2468,9 @@ importers:
       babel-loader: ^8.2.3
       clean-webpack-plugin: ^3.0.0
       cross-env: ^6.0.3
-      fela: ^12.0.2
-      fela-bindings: ^12.0.2
-      fela-dom: ^12.0.2
+      fela: ^12.1.0
+      fela-bindings: ^12.1.0
+      fela-dom: ^12.1.0
       prop-types: ^15.5.8
       react: ^17.0.2
       rimraf: ^3.0.0
@@ -2533,19 +2533,19 @@ importers:
       '@mdx-js/runtime': ^1.6.22
       '@next/bundle-analyzer': ^9.5.5
       copy-to-clipboard: ^3.3.1
-      fela: ^12.0.2
-      fela-dom: ^12.0.2
-      fela-plugin-named-keys: ^12.0.2
-      fela-plugin-responsive-value: ^12.0.2
-      fela-preset-web: ^12.0.2
-      fela-sort-media-query-mobile-first: ^12.0.2
+      fela: ^12.1.0
+      fela-dom: ^12.1.0
+      fela-plugin-named-keys: ^12.1.0
+      fela-plugin-responsive-value: ^12.1.0
+      fela-preset-web: ^12.1.0
+      fela-sort-media-query-mobile-first: ^12.1.0
       kilvin: ^3.1.1
       next: ^12.0.10
       next-mdx-remote: ^3.0.8
       prism-react-renderer: ^1.3.1
       react: ^17.0.2
       react-dom: ^17.0.2
-      react-fela: ^12.0.2
+      react-fela: ^12.1.0
       react-test-renderer: ^17.0.2
     dependencies:
       '@docsearch/react': 3.0.0-alpha.50_react-dom@17.0.2+react@17.0.2
@@ -10874,14 +10874,14 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /fela-bindings/12.0.2:
-    resolution: {integrity: sha512-d0bv4X/N/Rvrhj7Sq2nRx2BpkXWpKrGcgFb+ad1XamH2bbn/6s8D1N/7VtaxZBi6nS1dCU0xA4SXOYMAlXLLVw==}
+  /fela-bindings/12.1.0:
+    resolution: {integrity: sha512-JO+9ji/DeoNExDOqdySYnNJ+7vQO6+tWXzz7YlVTHAZD8G4LbrPqA0HTe1MQkNtwJe4ygUOUIlGkmV5XYbp0Sw==}
     peerDependencies:
       fela: '*'
     dependencies:
       fast-loops: 1.1.3
-      fela-dom: 12.0.2
-      fela-tools: 12.0.2
+      fela-dom: 12.1.0
+      fela-tools: 12.1.0
       react-addons-shallow-compare: 15.6.3
       shallow-equal: 1.2.1
     dev: false
@@ -10893,12 +10893,12 @@ packages:
       isobject: 3.0.1
     dev: true
 
-  /fela-dom/12.0.2:
-    resolution: {integrity: sha512-LEkrlggTKsGap7xnENvLayKMOcnEzFJD7ho3SP/jVXzVvmDdlZZM1O9hzDdP3hlt1yM2FRy1Fi1EAPOkEiWQOg==}
+  /fela-dom/12.1.0:
+    resolution: {integrity: sha512-/rbRQFujYAvRNkhvxW6W9Wthug4iR/vUZ/9PAqfBsVjkQssmMUoorNabZRiRkLvK+XTlIbPbfq1y9UgQiXU2dg==}
     dependencies:
       css-in-js-utils: 3.1.0
       fast-loops: 1.1.3
-      fela-utils: 12.0.2
+      fela-utils: 12.1.0
       sort-css-media-queries: 1.5.4
     dev: false
 
@@ -10914,17 +10914,17 @@ packages:
       fela-utils: 7.0.5
     dev: true
 
-  /fela-tools/12.0.2:
-    resolution: {integrity: sha512-ChtymUzulMavTktUddOO0JNnGvrb/dtrDacBKUbB6/4UOCso+K2lFQB8ZLfbhbiB33nYCb+ugkqJWBhh2CGVmg==}
+  /fela-tools/12.1.0:
+    resolution: {integrity: sha512-svWoE0wsbZmDQqWAQAtKx9roTQFWCJ7A8n7Ut1Ttx1xH+uEayZyj9pNjbWc5xFkRH/0YpFl5dgJUImLJSlNODA==}
     dependencies:
       css-in-js-utils: 3.1.0
       fast-loops: 1.1.3
-      fela: 12.0.2
-      fela-utils: 12.0.2
+      fela: 12.1.0
+      fela-utils: 12.1.0
     dev: false
 
-  /fela-utils/12.0.2:
-    resolution: {integrity: sha512-QileFjN2GCvVjf+7m8CckLalpG9UHU8dONAjkkF2q2kOZqipyTQl8rfqchHEdXgUrYEqE7lfTWfV/VTJH+FnNw==}
+  /fela-utils/12.1.0:
+    resolution: {integrity: sha512-z7lRHXhDt/x9jm2yVd5b/apxjlADQ13+SXGKt7isv88TN6dLqn7NN9o4mrFbOchsa9XuVU88nyhNkd8rLdudeA==}
     dependencies:
       css-in-js-utils: 3.1.0
       fast-loops: 1.1.3
@@ -10936,13 +10936,13 @@ packages:
       css-in-js-utils: 2.0.0
     dev: true
 
-  /fela/12.0.2:
-    resolution: {integrity: sha512-iYQB/li1IBLlhJobppwKdU1fasX64hqqpDACbK1j4i8uAT/O8q2SwwLi9PSAf5Tm2T1Y+JlsebUMPBu69axMcg==}
+  /fela/12.1.0:
+    resolution: {integrity: sha512-TLHqNVkYEO3Z4U8+XFPBvF5xHxo4qiM4W8NzYH7kfODW0QdNaOG7prmyLFVVVxvlDyPd8XY2zH6Humb459zTXw==}
     dependencies:
       css-in-js-utils: 3.1.0
       csstype: 3.0.10
       fast-loops: 1.1.3
-      fela-utils: 12.0.2
+      fela-utils: 12.1.0
       isobject: 3.0.1
     dev: false
 
@@ -21350,13 +21350,13 @@ packages:
     resolution: {directory: packages/react-fela, type: directory}
     id: file:packages/react-fela
     name: react-fela
-    version: 12.0.2
+    version: 12.1.0
     peerDependencies:
-      fela: '>= 11.3.1'
+      fela: '>=11.3'
       react: '*'
     dependencies:
-      fela-bindings: 12.0.2
-      fela-dom: 12.0.2
+      fela-bindings: 12.1.0
+      fela-dom: 12.1.0
       prop-types: 15.8.1
       react: 17.0.2
     dev: false


### PR DESCRIPTION
## Description
Fixes error due to not defined `ReactDOMClient` and switches `root` and `node` in `createRoot`

## Packages

- jest-react-fela

## Versioning
Patch

## Checklist

#### Quality Assurance

> You can also run `pnpm run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`pnpm run format`)
- [x] The code has no linting errors (`pnpm run lint`)
- [x] All tests are passing (`pnpm run test`)

#### Changes

If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [ ] Documentation has been added/updated
