### PR TITLE
Update rules docs: pseudo elements, feature queries

### DIFF
--- a/website/docs/latest/basics/rules.mdx
+++ b/website/docs/latest/basics/rules.mdx
@@ -56,13 +56,17 @@ const rule = (props) => ({
     color: 'black',
   },
   // make sure you are using nested quotes to set the content.
-  ':before': {
+  '::before': {
     content: '" "',
+  },
+  // conbination without nesting works too
+  ':hover::after': {
+    content: '"hello"',
   },
 })
 ```
 
-> **Note:** When using `:before` pseudo selector, make sure you are using nested quotes to set the content. Eg: `content: '" "'`
+> **Note:** When using `::before` or `::after` pseudo elements, make sure you are using nested quotes to set the content. Eg: `content: '" "'`
 
 ### Media Queries
 

--- a/website/docs/latest/basics/rules.mdx
+++ b/website/docs/latest/basics/rules.mdx
@@ -36,9 +36,9 @@ const rule = (props) => ({
 })
 ```
 
-### Pseudo Classes
+### Pseudo Classes and Pseudo Elements
 
-Pseudo classes are one of the key features of CSS. They let you add interactive behavior to your basic styles. You can easily define them as nested property objects within your rules. You can also nest them to require both pseudo classes to be active.
+Pseudo classes and pseudo elements are one of the key features of CSS. They let you add interactive behavior to your basic styles or create additional elements for styling purposes. You can easily define them as nested property objects within your rules. You can also nest them if you wish to combine them the resulted styles. Combining them in a single string works too.
 
 ```javascript
 const rule = (props) => ({
@@ -92,9 +92,9 @@ const rule = (props) => ({
 })
 ```
 
-### Support Queries
+### Feature Queries
 
-Another useful CSS feature are [support queries](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports).<br />
+Another useful CSS feature are [feature queries](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports).<br />
 They're used to conditionally apply CSS values **only** if a certain CSS feature is supported by the targeted browser. This helps to provide the best experience for both modern and old browsers.
 
 ```javascript

--- a/website/docs/latest/intro/caveats.mdx
+++ b/website/docs/latest/intro/caveats.mdx
@@ -29,11 +29,11 @@ There are three options to solve this with Fela. We recommend using [fela-enforc
 
 ## CSS properties that contain double quotes
 
-For css properties that need double quotes, make sure you are using nested quotes in your code. e.g.:
+For CSS properties that need double quotes, make sure you are using nested quotes in your code. e.g.:
 
 ```javascript nocopy
 const rule = (props) => ({
-  ':before': {
+  '::before': {
     content: '" "',
   },
 })


### PR DESCRIPTION
## Description

I’ve been reading the docs and discovered a few places that could be improved. This PR is focused on basics/rules.mdx, but I have a few more improvements in other parts. Please let me know if I should use other PRs for them or combine everything in one place.

Here’s the following:

- `::before` is a pseudo element, not pseudo class
- It’s preferable to use double colons to differentiate elements from classes (according to spec)
- It’s worth mentioning that pseudo classes/elements could be combined in a single string, not just nested
- `@supports` is a part of Feature queries, not Support queries

## Checklist

#### Quality Assurance

- [x] The code was formatted using Prettier (`pnpm run format`)
- [x] The code has no linting errors (`pnpm run lint`)
- [x] All tests are passing (`pnpm run test`)

#### Changes

- [x] Tests have been added/updated
- [x] Documentation has been added/updated