### PR TITLE
fix: add children prop to ProviderProps and ThemeProviderProps

### DIFF
--- a/packages/react-fela/index.d.ts
+++ b/packages/react-fela/index.d.ts
@@ -13,6 +13,7 @@ declare module "react-fela" {
   interface ThemeProviderProps {
     theme: object;
     overwrite?: boolean;
+    children: React.ReactNode;
   }
 
   /**
@@ -35,6 +36,7 @@ declare module "react-fela" {
     renderer: object;
     rehydrate?: boolean;
     targetDocument?: any;
+    children: React.ReactNode;
   }
 
   interface FelaWithThemeProps<Theme> {


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description

After I had updated `fela` and `react-fela` to the version `12.1.1`, I started getting the following error, in a Nextjs-based project and in a CRA-based project, both using Typescript.

```
'RendererProvider' cannot be used as a JSX component.
  Its instance type 'RendererProvider' is not a valid JSX element.
    Type 'RendererProvider' is missing the following properties from type 'ElementClass': render, context, setState, forceUpdate, and 3 more.
```

## Example

If required, add a code example or a link to a working example (repository).

![Screenshot_2022-05-03_at_12_32_56](https://user-images.githubusercontent.com/1679333/166446943-c8fedb9b-0a25-4819-8875-3ddbcb5b9920.png)
![Screenshot_2022-05-03_at_12_33_05](https://user-images.githubusercontent.com/1679333/166446945-ac0a9fe6-5c4c-4baa-a2da-1eac794cc8e6.png)

## Packages

List all packages that have been changed.

- `react-fela`

## Versioning

None / Patch / Minor / Major

## Checklist

#### Quality Assurance

> You can also run `pnpm run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`pnpm run format`)
- [x] The code has no linting errors (`pnpm run lint`)
- [x] All tests are passing (`pnpm run test`)

#### Changes

If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
