### PR TITLE
Add staticStyle to FelaHookProps

### DIFF
--- a/packages/react-fela/index.d.ts
+++ b/packages/react-fela/index.d.ts
@@ -581,6 +581,7 @@ declare module "react-fela" {
       css: CssFunction<T, P>,
       theme: T,
       renderer: IRenderer,
+      staticStyle: IRenderer["renderStatic"],
     }
 
     export function useFela<T = {}, P = {}>(props?: P): FelaHookProps<T, P>


### PR DESCRIPTION
While trying out fela, I ran into the following TypeScript error. This PR corrects the error.

> Property 'staticStyle' does not exist on type 'FelaHookProps<{}, {}>'.

## Example

```typescript
import { useFela } from "react-fela";

function MyComponent() {
  const { staticStyle } = useFela();

  staticStyle("* { box-sizing: border-box; }");

  return null;
}
```

## Packages

This PR changes the following packages:

- react-fela

## Versioning

Minor

## Checklist

#### Quality Assurance

> You can also run `pnpm run check` to run all 4 commands at once.

- [X] The code was formatted using Prettier (`pnpm run format`)
- [X] The code has no linting errors (`pnpm run lint`)
- [X] All tests are passing (`pnpm run test`)

#### Changes

If one of the following checks doesn't make sense due to the type of PR, just check them.

- [X] Tests have been added/updated
- [X] Documentation has been added/updated
