### PR TITLE
Updated IConfig interface

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -92,6 +92,9 @@ declare module 'fela' {
     specificityPrefix?: string
     filterClassName?: (className: string) => boolean
     devMode?: boolean
+    optimizeCaching?: boolean
+    styleNodeAttributes?: { [key: string]: string }
+    propertyPriority?: { [key: string]: number }
   }
 
   type CSSObject = CSSProperties & CSSPseudos


### PR DESCRIPTION
## Description

adds three missing options

* optimizeCaching
* styleNodeAttributes
* propertyPriority

to the IConfig interface (#905).

## Packages

- fela


## Checklist

#### Quality Assurance

> You can also run `pnpm run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`pnpm run format`)
- [ ] The code has no linting errors (`pnpm run lint`)
- [x] All tests are passing (`pnpm run test`)

I tried to run ```pnpm run lint``` bit it gives me a myriad of problems and warnings :/ 
I followed https://github.com/robinweser/fela/blob/master/.github/CONTRIBUTING.md, am I something missing?

#### Changes

If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
