### PR TITLE
chore: Link to truss.

### DIFF
--- a/website/docs/latest/intro/ecosystem.mdx
+++ b/website/docs/latest/intro/ecosystem.mdx
@@ -124,6 +124,7 @@ Many plugins and enhancers are already included in the [main repository](https:/
 - [storybook-addon-props-fela](https://github.com/Kilix/storybook-addon-props-fela) - Document the props of your Fela components in storybook.
 - [black-box](https://github.com/rocketstation/black-box) - combines behavior, presentation, structure in one place & creates all-in-one components using only JS syntax
 - [small-color](https://github.com/robinweser/small-color) - A tiny (0.8kb gzipped) color manipulation package
+- [Truss](https://github.com/homebound-team/truss/) - TypeScript DSL for writing Tachyons/Tailwinds-style inline/utility CSS but in Fela
 
 ---
 


### PR DESCRIPTION
## Description

Linking to our Truss open source project, which can be used with Fela.

(deleted the rest of the template as N/A)
