### PR TITLE
fix: include children prop in ruleProps

### DIFF
--- a/packages/fela-bindings/src/createComponentFactory.js
+++ b/packages/fela-bindings/src/createComponentFactory.js
@@ -77,6 +77,7 @@ export default function createComponentFactory(
             theme: _felaTheme,
             as,
             id,
+            children,
           }
 
           // if the component renders into another Fela component


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description

This PR allows style rules to be conditionally applied based on (for example) the presence or absence of any children passed to the component. Previously, `props.children` was not available within a style rule function.

I wasn't sure where the best place to include a test for this is. There don't seem to be any relevant tests within `fela-bindings`, but let me know if you'd like me to include a test in one of the downstream packages and I'll be happy to add one.

## Packages

List all packages that have been changed.

`fela-bindings`

## Versioning

Patch

## Checklist

#### Quality Assurance

> You can also run `pnpm run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`pnpm run format`)
- [x] The code has no linting errors (`pnpm run lint`)
- [x] All tests are passing (`pnpm run test`)

#### Changes

If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
